### PR TITLE
Added 'branch' version access to TRAPI schemata

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -54,11 +54,11 @@ async def validate(query: Query):
     if not query.response:
         raise HTTPException(status_code=400, detail="Empty input message?")
 
-    trapi_version: str = latest.get(query.trapi_version)
-    print(f"trapi_version == {trapi_version}", file=stderr)
+    trapi_version: Optional[str] = query.trapi_version
+    print(f"Specified trapi_version == {trapi_version}", file=stderr)
 
-    biolink_version: str = query.biolink_version
-    print(f"biolink_version == {biolink_version}", file=stderr)
+    biolink_version: Optional[str] = query.biolink_version
+    print(f"Specified biolink_version == {biolink_version}", file=stderr)
 
     sources: Optional[Sources] = query.sources
     print(f"Validation Context == {sources}", file=stderr)

--- a/reasoner_validator/biolink/__init__.py
+++ b/reasoner_validator/biolink/__init__.py
@@ -257,22 +257,23 @@ class BiolinkValidator(ValidationReporter):
         element: Optional[Element] = self.bmt.get_element(name)
         if not element:
             self.report(code=f"error.{context}.unknown", name=name)
+            return None
         elif element.deprecated:
             self.report(code=f"warning.{context}.deprecated", name=name)
-            return None
+            # return None - a deprecated term is not treated as a failure but just as a warning
         elif element.abstract:
             if self.strict_validation:
                 self.report(code=f"error.{context}.abstract",  name=name)
+                return None
             else:
                 self.report(code=f"info.{context}.abstract", name=name)
-            return None
         elif self.bmt.is_mixin(name):
-            # A mixin cannot be instantiated thus it should not be given as an input concept category
+            # A mixin cannot be instantiated ...
             if self.strict_validation:
                 self.report(code=f"error.{context}.mixin", name=name)
+                return None
             else:
                 self.report(code=f"info.{context}.mixin", name=name)
-            return None
         else:
             return element
 

--- a/reasoner_validator/report.py
+++ b/reasoner_validator/report.py
@@ -51,8 +51,8 @@ class ValidationReporter:
         """
         :param prefix: named context of the Validator, used as a prefix in validation messages.
         :type prefix: str
-        :param trapi_version: version of component against which to validate the message (mandatory, no default assumed).
-        :type trapi_version: str
+        :param trapi_version: version of component against which to validate the message. May be a TRAPI release SemVer or a Git branch identifier.
+        :type trapi_version: Optional[str], target version of TRAPI upon which the validation is attempted
         :param biolink_version: Biolink Model (SemVer) release against which the knowledge graph is to be
                                 validated (Default: if None, use the Biolink Model Toolkit default version.
         :type biolink_version: Optional[str] = None

--- a/reasoner_validator/versioning.py
+++ b/reasoner_validator/versioning.py
@@ -15,13 +15,18 @@ GIT_ORG = environ.setdefault('GIT_ORGANIZATION', "NCATSTranslator")
 GIT_REPO = environ.setdefault('GIT_REPOSITORY', "ReasonerAPI")
 
 response = requests.get(f"https://api.github.com/repos/{GIT_ORG}/{GIT_REPO}/releases")
-releases = response.json()
+release_data = response.json()
 versions = [
     release["tag_name"][1:]
-    for release in releases
+    for release in release_data
     if release["tag_name"].startswith("v")
 ]
 
+response = requests.get(f"https://api.github.com/repos/{GIT_ORG}/{GIT_REPO}/branches")
+branch_data = response.json()
+branches = [
+    branch["name"] for branch in branch_data
+]
 
 semver_pattern = re.compile(
     r"^(?P<major>0|[1-9]\d*)(\.(?P<minor>0|[1-9]\d*)(\.(?P<patch>0|[1-9]\d*))?)?" +

--- a/tests/test_biolink_compliance_validation.py
+++ b/tests/test_biolink_compliance_validation.py
@@ -802,7 +802,7 @@ def get_ara_test_case(changes: Optional[Dict[str, str]] = None):
 @pytest.mark.parametrize(
     "query",
     [
-        ( "", "" )
+        ( "", "", "" )
     ]
 )
 def test_validate_attribute_constraints(query: Tuple):
@@ -1052,7 +1052,7 @@ def test_validate_attributes(query: Tuple):
 @pytest.mark.parametrize(
     "query",
     [
-        ( "", "" )
+        ( "", "", "")
     ]
 )
 def test_validate_qualifier_constraints(query: Tuple):
@@ -1068,7 +1068,7 @@ def test_validate_qualifier_constraints(query: Tuple):
 @pytest.mark.parametrize(
     "query",
     [
-        ( "", "" )
+        ( "", "", "" )
     ]
 )
 def test_validate_qualifiers(query: Tuple):

--- a/tests/test_biolink_compliance_validation.py
+++ b/tests/test_biolink_compliance_validation.py
@@ -171,12 +171,12 @@ KNOWLEDGE_GRAPH_PREFIX = f"{BLM_VERSION_PREFIX} Knowledge Graph"
             {
                 'subject_category': 'biolink:Drug',
                 'object_category': 'biolink:Protein',
-                'predicate': 'biolink:has_real_world_evidence_of_association_with',
+                'predicate': 'biolink:increases_amount_or_activity_of',
                 'subject': 'NDC:0002-8215-01',  # a form of insulin
                 'object': 'MONDO:0005148'  # type 2 diabetes?
             },
             # f"{INPUT_EDGE_PREFIX}: WARNING - Predicate element " +
-            # "'has_real_world_evidence_of_association_with' is deprecated?"
+            # "'binds' is deprecated?"  # in Biolink 3.1.1
             "warning.input_edge.edge.predicate.deprecated"
         ),
         (   # Query 8 - Predicate is abstract
@@ -194,10 +194,10 @@ KNOWLEDGE_GRAPH_PREFIX = f"{BLM_VERSION_PREFIX} Knowledge Graph"
         (   # Query 9 - Predicate is a mixin
             LATEST_BIOLINK_MODEL,
             {
-                'subject_category': 'biolink:AnatomicalEntity',
+                'subject_category': 'biolink:SmallMolecule',
                 'object_category': 'biolink:AnatomicalEntity',
-                'predicate': 'biolink:regulates',
-                'subject': 'UBERON:0005453',
+                'predicate': 'biolink:biological_role_mixin',
+                'subject': 'CHEBI:15355',
                 'object': 'UBERON:0035769'
             },
             # f"{INPUT_EDGE_PREFIX}: INFO - Predicate element 'biolink:regulates' is a mixin."
@@ -298,18 +298,18 @@ KNOWLEDGE_GRAPH_PREFIX = f"{BLM_VERSION_PREFIX} Knowledge Graph"
             },
             ""
         ),
-        (   # Query 18 - Deprecated
-            LATEST_BIOLINK_MODEL,
-            {
-                'subject_category': 'biolink:Nutrient',
-                'object_category': 'biolink:Protein',
-                'predicate': 'biolink:physically_interacts_with',
-                'subject': 'CHEBI:27300',
-                'object': 'Orphanet:120464'
-            },
-            # f"{INPUT_EDGE_PREFIX}: WARNING - Subject 'biolink:Nutrient' is deprecated?"
-            "warning.input_edge.node.category.deprecated"
-        ),
+        # (   # Query 18 - Deprecated - don't have any more deprecated categories in Biolink 3.1.1
+        #     LATEST_BIOLINK_MODEL,
+        #     {
+        #         'subject_category': 'biolink:Nutrient',
+        #         'object_category': 'biolink:Protein',
+        #         'predicate': 'biolink:physically_interacts_with',
+        #         'subject': 'CHEBI:27300',
+        #         'object': 'Orphanet:120464'
+        #     },
+        #     # f"{INPUT_EDGE_PREFIX}: WARNING - Subject 'biolink:Nutrient' is deprecated?"
+        #     "warning.input_edge.node.category.deprecated"
+        # ),
         (   # Query 19 - inform that the input category is a mixin?
             LATEST_BIOLINK_MODEL,
             {

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -6,7 +6,7 @@ from jsonschema.exceptions import ValidationError
 
 from reasoner_validator.trapi import TRAPISchemaValidator, openapi_to_jsonschema
 
-TEST_VERSIONS = "1", "1.2", "1.2.0", "1.3", "1.3.0"
+TEST_VERSIONS = "1", "1.2", "1.2.0", "1.3", "1.3.0", "master"  # last 'version' is a branch name, i.e. master?
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This code base is also in migration towards 3.1.1 so several Biolink Model compliance unit tests are broken at the moment (not too much a reason to fret... mostly deprecated etc. terms, not the core validation)