### PR TITLE
Biolink 3 qualifier code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 The Reasoner Validator package is evolving along with progress in TRAPI and Biolink standards within the NCATS Biomedical Knowledge Translator. 
 
+### v3.3.2
+
+- Upgrade Python dependency to ^3.9 (BMT driven requirement)
+- Upgrade Biolink Model Toolkit (BMT) to 1.0.2 to gain access to latest Biolink 3 qualifier validation methods
+- Relatively full implementation of the Query Graph qualifier_constraints and Knowledge Graph qualifiers validation
+- Added some new and repaired some existing validation codes and unit tests - all unit tests pass (TRAPI 1.3 and Biolink 3.2.0)
+
+### v3.3.1
+
+- updated root project README with correct examples of new ValidationReporter JSON output
+- initial code to (partly) validate Biolink 3 edge qualifiers (still more work needed once Biolink Model Toolkit support for validation is available)
+
 ### v3.3.0
 
 - ValidationReporter internal message format recoded to avoid message duplication; repeated reporting of a given code is now indexed into a single list of error message parameters; Conversely, 'display()' methods now return lists of decoded messages.

--- a/docs/validation_codes_dictionary.md
+++ b/docs/validation_codes_dictionary.md
@@ -26,13 +26,13 @@
 
 **Description:** Input Edge data can have 'mixin' category classes.
 
-### info.input_edge.edge.predicate.abstract
+### info.input_edge.predicate.abstract
 
 **Message:** '{name}' is abstract.
 
 **Description:** Input Edge data can have 'abstract' predicates.
 
-### info.input_edge.edge.predicate.mixin
+### info.input_edge.predicate.mixin
 
 **Message:** '{name}' is a mixin.
 
@@ -106,13 +106,13 @@
 
 **Description:** The namespaces of Biolink model node of specified category may be incomplete with respect to identifiers being used in input edge data?
 
-### warning.input_edge.edge.predicate.deprecated
+### warning.input_edge.predicate.deprecated
 
 **Message:** '{name}' is deprecated?
 
 **Description:** Input data edge predicate is deprecated in the current model, to be removed in the future. Review Biolink Model for a suitable replacement?
 
-### warning.input_edge.edge.predicate.non_canonical
+### warning.input_edge.predicate.non_canonical
 
 **Message:** {context} edge {edge_id} predicate '{predicate}' is non-canonical?
 
@@ -282,11 +282,17 @@
 
 **Description:** TRAPI Message.Results cannot resolve its reported identifier mappings to the original query.
 
+### error.input_edge.node.category.missing
+
+**Message:** Input edge node '{node_id}' is missing its category!
+
+**Description:** Category value must be specified in an input test data edge!
+
 ### error.input_edge.node.category.unknown
 
-**Message:** '{name}' is unknown!
+**Message:** Input edge node '{node_id}' has unknown category '{category}'!
 
-**Description:** Category specified in input test data edge node is not recorded in specified version of Biolink. Replace with a concrete category!
+**Description:** Category specified in input test data edge node is not recorded in specified version of Biolink. Replace with a known category!
 
 ### error.input_edge.node.category.abstract
 
@@ -306,23 +312,35 @@
 
 **Description:** Input test data edge data needs to have a specific node identifier for testing!
 
-### error.input_edge.edge.predicate.missing
+### error.input_edge.predicate.missing
 
 **Message:** {context} edge '{edge_id}' predicate is missing or empty!
 
 **Description:** Input test edge data needs to have a specific edge predicate for testing!
 
-### error.input_edge.edge.predicate.abstract
+### error.input_edge.predicate.unknown
 
-**Message:** '{name}' is abstract!
+**Message:** '{name}' is unknown predicate!
 
-**Description:** Input Edge data validation is currently strict: cannot have 'abstract' predicates!
+**Description:** Predicate specified in input test data edge is not recorded in specified version of Biolink. Replace with a known predicate!
 
-### error.input_edge.edge.predicate.mixin
+### error.input_edge.predicate.abstract
 
-**Message:** '{name}' is a mixin1
+**Message:** '{name}' is abstract predicate!
 
-**Description:** Input Edge data validation is currently strict: cannot have 'mixin' predicates!
+**Description:** Input Edge data validation is currently strict: predicates cannot be 'abstract'. Replace with a concrete predicate!
+
+### error.input_edge.predicate.mixin
+
+**Message:** '{name}' is a mixin predicate!
+
+**Description:** Input Edge data validation is currently strict: predicates cannot be of type 'mixin'. Replace with a concrete predicate!
+
+### error.input_edge.predicate.invalid
+
+**Message:** Edge '{edge_id}' predicate '{predicate}' is invalid!
+
+**Description:** Predicate specified in Input Edge is not defined as a predicate in specified version of Biolink. Replace with a proper predicate!
 
 ### error.query_graph.node.category.unknown
 
@@ -360,11 +378,41 @@
 
 **Description:** The 'is_set' field in node of Query Graph, if present, must be a boolean value!
 
+### error.query_graph.edge.subject.missing
+
+**Message:** Edge '{edge_id}' has a missing or empty 'subject' slot value!
+
+**Description:** Query graph edge must have a 'subject' key with a non-empty associated value!
+
+### error.query_graph.edge.subject.missing_from_nodes
+
+**Message:** Edge 'subject' id '{object_id}' is missing from the nodes catalog!
+
+**Description:** Every 'subject' identifier of every edge in a Query Graph must also be recorded in the list of nodes for that graph!
+
+### error.query_graph.edge.object.missing
+
+**Message:** Edge '{edge_id}' has a missing or empty 'object' slot value!
+
+**Description:** Query graph edge must have a 'object' key with a non-empty associated value!
+
+### error.query_graph.edge.object.missing_from_nodes
+
+**Message:** Edge 'object' id '{object_id}' is missing from the nodes catalog!
+
+**Description:** Every 'object' identifier of every edge in a Query Graph must also be recorded in the list of nodes for that graph!
+
 ### error.query_graph.edge.predicate.missing
 
 **Message:** Edge '{edge_id}' predicate is missing or empty!
 
 **Description:** The predicate of Query Graph edge needs to specified using a 'predicate' key with an array list of one or more predicates!
+
+### error.query_graph.edge.predicate.unknown
+
+**Message:** Edge '{edge_id}' predicate '{predicate}' is unknown!
+
+**Description:** Predicate specified in Query Graph edge is not defined in specified version of Biolink. Replace with a defined predicate!
 
 ### error.query_graph.edge.predicate.not_array
 
@@ -390,41 +438,29 @@
 
 **Description:** Query Graph data validation is currently strict: cannot have 'mixin' predicates!
 
+### error.query_graph.edge.predicate.invalid
+
+**Message:** Edge '{edge_id}' predicate '{predicate}' is invalid!
+
+**Description:** Predicate specified in Query Graph edge is not defined as a predicate in specified version of Biolink. Replace with a proper predicate!
+
 ### error.query_graph.edge.attribute_constraints.not_array
 
 **Message:** Edge '{edge_id}' attribute_constraints property value is not an array!
 
 **Description:** Value of 'attribute_constraints' slot value in a Query Graph must be an array data type!
 
-### error.query_graph.edge.qualifier_constraints.qualifier_set.value.invalid
+### error.query_graph.edge.qualifier_constraints.qualifier_set.empty
 
-**Message:** Edge '{edge_id}' qualifier_set property value is empty or not a JSON object!
+**Message:** Edge '{edge_id}' qualifier_set property value is empty!
 
-**Description:** Value of a 'qualifier_set' property in a Query Graph must be non-empty array!
+**Description:** Value of a 'qualifier_constraints.qualifier_set' property in a Query Graph must not be non-empty array!
 
-### error.query_graph.edge.qualifier_constraints.qualifier_set.value.qualifier.qualifier_type_id.not_biolink_curie
+### error.query_graph.edge.qualifier_constraints.qualifier_set.qualifier.invalid
 
-**Message:** Edge '{edge_id}' qualifier_type_id {identifier} is not a Biolink CURIE!
+**Message:** Edge '{edge_id}' qualifier entry is invalid!
 
-**Description:** A qualifier qualifier_type_id property value in a Query Graph must be a Biolink CURIE!
-
-### error.query_graph.edge.qualifier_constraints.qualifier_set.value.qualifier.qualifier_type_id.unknown
-
-**Message:** Edge '{edge_id}' qualifier_type_id {identifier} is unknown!
-
-**Description:** This 'qualifier_type_id' in the Query Graph is undefined in the Biolink Model!
-
-### error.query_graph.edge.qualifier_constraints.qualifier_set.value.qualifier.qualifier_type_id.invalid
-
-**Message:** Edge '{edge_id}' qualifier_type_id {identifier} is not a valid Biolink qualifier type id!
-
-**Description:** This 'qualifier_type_id' in the Query Graph not properly defined in the Biolink Model!
-
-### error.query_graph.edge.qualifier_constraints.qualifier_set.value.qualifier.qualifier_type_id.range.missing
-
-**Message:** The value range of edge '{edge_id}' qualifier_type_id {identifier} is undefined!
-
-**Description:** The 'qualifier_type_id' in the Query Graph needs to have a defined enum or category value range!
+**Description:** A 'qualifier' entry must be a valid JSON object with valid 'qualifier_type_id' and corresponding 'qualifier_value'!
 
 ### error.knowledge_graph.nodes.empty
 

--- a/docs/validation_codes_dictionary.md
+++ b/docs/validation_codes_dictionary.md
@@ -68,6 +68,12 @@
 
 **Description:** Non-Biolink CURIEs are tolerated as term value for the attribute_type_id properties of edge attributes.
 
+### info.knowledge_graph.node.category.abstract
+
+**Message:** '{name}' is abstract.
+
+**Description:** TRAPI Message Knowledge Graphs can have 'abstract' category classes when mode of validation is 'non-strict'.
+
 ## Warning
 
 ### warning.trapi.response.status.unknown
@@ -665,4 +671,16 @@
 **Message:** Edge '{edge_id}' 'qualifiers' are not an array!
 
 **Description:** Value of the 'qualifiers' slot in Knowledge Graph edge must be an array of attributes!
+
+### error.knowledge_graph.edge.qualifiers.empty
+
+**Message:** Edge '{edge_id}' qualifiers property value is empty!
+
+**Description:** Value of a 'qualifiers' property in a Knowledge Graph must not be non-empty array!
+
+### error.knowledge_graph.edge.qualifiers.qualifier.invalid
+
+**Message:** Edge '{edge_id}' qualifier entry is invalid!
+
+**Description:** A 'qualifier' entry must be a valid JSON object with valid 'qualifier_type_id' and corresponding 'qualifier_value'!
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -305,7 +305,7 @@ test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
 
 [[package]]
 name = "cryptography"
-version = "39.0.0"
+version = "39.0.1"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
 optional = false
@@ -315,12 +315,14 @@ python-versions = ">=3.6"
 cffi = ">=1.12"
 
 [package.extras]
-docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1,!=5.2.0,!=5.2.0.post0)", "sphinx-rtd-theme"]
+docs = ["sphinx (>=5.3.0)", "sphinx-rtd-theme (>=1.1.1)"]
 docstest = ["pyenchant (>=1.6.11)", "sphinxcontrib-spelling (>=4.0.1)", "twine (>=1.12.0)"]
-pep8test = ["black", "ruff"]
+pep8test = ["black", "check-manifest", "mypy", "ruff", "types-pytz", "types-requests"]
 sdist = ["setuptools-rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["hypothesis (>=1.11.4,!=3.79.2)", "iso8601", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-subtests", "pytest-xdist", "pytz"]
+test = ["hypothesis (>=1.11.4,!=3.79.2)", "iso8601", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-shard (>=0.1.2)", "pytest-subtests", "pytest-xdist", "pytz"]
+test-randomorder = ["pytest-randomly"]
+tox = ["tox"]
 
 [[package]]
 name = "curies"
@@ -467,16 +469,16 @@ testing = ["covdefaults (>=2.2.2)", "coverage (>=7.0.1)", "pytest (>=7.2)", "pyt
 
 [[package]]
 name = "flake8"
-version = "5.0.4"
+version = "6.0.0"
 description = "the modular source code checker: pep8 pyflakes and co"
 category = "main"
 optional = false
-python-versions = ">=3.6.1"
+python-versions = ">=3.8.1"
 
 [package.dependencies]
 mccabe = ">=0.7.0,<0.8.0"
-pycodestyle = ">=2.9.0,<2.10.0"
-pyflakes = ">=2.5.0,<2.6.0"
+pycodestyle = ">=2.10.0,<2.11.0"
+pyflakes = ">=3.0.0,<3.1.0"
 
 [[package]]
 name = "fqdn"
@@ -920,7 +922,7 @@ regex = ["regex"]
 
 [[package]]
 name = "linkml"
-version = "1.4.3"
+version = "1.4.4"
 description = "Linked Open Data Modeling Language"
 category = "main"
 optional = false
@@ -993,7 +995,7 @@ docs = ["myst-parser[docs] (>=0.18.1,<0.19.0)", "sphinx-autodoc-typehints[docs] 
 
 [[package]]
 name = "linkml-runtime"
-version = "1.4.3"
+version = "1.4.5"
 description = "Runtime environment for LinkML, the Linked open data modeling language"
 category = "main"
 optional = false
@@ -1106,7 +1108,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "mypy"
-version = "0.991"
+version = "1.0.0"
 description = "Optional static typing for Python"
 category = "main"
 optional = false
@@ -1125,11 +1127,11 @@ reports = ["lxml"]
 
 [[package]]
 name = "mypy-extensions"
-version = "0.4.3"
-description = "Experimental type system extensions for programs checked with the mypy typechecker."
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.5"
 
 [[package]]
 name = "myst-parser"
@@ -1182,7 +1184,7 @@ test = ["codecov (>=2.1)", "pytest (>=7.2)", "pytest-cov (>=4.0)"]
 
 [[package]]
 name = "numpy"
-version = "1.24.1"
+version = "1.24.2"
 description = "Fundamental package for array computing in Python"
 category = "main"
 optional = false
@@ -1392,15 +1394,15 @@ testing = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "platformdirs"
-version = "2.6.2"
+version = "3.0.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.5)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
+docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.22,!=1.23.4)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
 
 [[package]]
 name = "pluggy"
@@ -1491,7 +1493,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pycodestyle"
-version = "2.9.1"
+version = "2.10.0"
 description = "Python style guide checker"
 category = "main"
 optional = false
@@ -1522,7 +1524,7 @@ email = ["email-validator (>=1.0.3)"]
 
 [[package]]
 name = "pyflakes"
-version = "2.5.0"
+version = "3.0.1"
 description = "passive checker of Python programs"
 category = "main"
 optional = false
@@ -1940,7 +1942,7 @@ SQLAlchemy-Utils = ">=0.38.2,<0.39.0"
 
 [[package]]
 name = "setuptools"
-version = "67.0.0"
+version = "67.2.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "main"
 optional = false
@@ -2080,15 +2082,16 @@ sphinx = ">=2.0"
 
 [[package]]
 name = "sphinx-rtd-theme"
-version = "1.1.1"
+version = "1.2.0"
 description = "Read the Docs theme for Sphinx"
 category = "main"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 
 [package.dependencies]
-docutils = "<0.18"
-sphinx = ">=1.6,<6"
+docutils = "<0.19"
+sphinx = ">=1.6,<7"
+sphinxcontrib-jquery = {version = ">=2.0.0,<3.0.0 || >3.0.0", markers = "python_version > \"3\""}
 
 [package.extras]
 dev = ["bump2version", "sphinxcontrib-httpdomain", "transifex-client", "wheel"]
@@ -2128,6 +2131,17 @@ python-versions = ">=3.8"
 [package.extras]
 lint = ["docutils-stubs", "flake8", "mypy"]
 test = ["html5lib", "pytest"]
+
+[[package]]
+name = "sphinxcontrib-jquery"
+version = "2.0.0"
+description = "Extension to include jQuery on newer Sphinx releases"
+category = "main"
+optional = false
+python-versions = ">=2.7"
+
+[package.dependencies]
+setuptools = "*"
 
 [[package]]
 name = "sphinxcontrib-jsmath"
@@ -2467,20 +2481,20 @@ test = ["flake8 (>=2.4.0)", "isort (>=4.2.2)", "pytest (>=2.2.3)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.17.1"
+version = "20.19.0"
 description = "Virtual Python Environment builder"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 distlib = ">=0.3.6,<1"
 filelock = ">=3.4.1,<4"
-platformdirs = ">=2.4,<3"
+platformdirs = ">=2.4,<4"
 
 [package.extras]
-docs = ["proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-argparse (>=0.3.2)", "sphinx-rtd-theme (>=1)", "towncrier (>=22.8)"]
-testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=21.3)", "pytest (>=7.0.1)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.6.1)", "pytest-randomly (>=3.10.3)", "pytest-timeout (>=2.1)"]
+docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=22.12)"]
+test = ["covdefaults (>=2.2.2)", "coverage (>=7.1)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23)", "pytest (>=7.2.1)", "pytest-env (>=0.8.1)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.10)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)"]
 
 [[package]]
 name = "watchdog"
@@ -2511,7 +2525,7 @@ python-versions = "*"
 
 [[package]]
 name = "websocket-client"
-version = "1.5.0"
+version = "1.5.1"
 description = "WebSocket client for Python with low level API options"
 category = "main"
 optional = false
@@ -2544,7 +2558,7 @@ multidict = ">=4.0"
 
 [[package]]
 name = "zipp"
-version = "3.12.0"
+version = "3.12.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
@@ -2560,7 +2574,7 @@ docs = ["numpydoc", "sphinx", "myst-parser"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "0d19b64abb9ed1ffe4c47631f4beaae10e423ff763eb18382edc6ed67d44d614"
+content-hash = "592e13dcc9f5595f423411f6cddcddda7e02b99e004a2aaaac533017efd80cc6"
 
 [metadata.files]
 aiohttp = [
@@ -2830,29 +2844,27 @@ commonmark = [
     {file = "commonmark-0.9.1.tar.gz", hash = "sha256:452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60"},
 ]
 cryptography = [
-    {file = "cryptography-39.0.0-cp36-abi3-macosx_10_12_universal2.whl", hash = "sha256:c52a1a6f81e738d07f43dab57831c29e57d21c81a942f4602fac7ee21b27f288"},
-    {file = "cryptography-39.0.0-cp36-abi3-macosx_10_12_x86_64.whl", hash = "sha256:80ee674c08aaef194bc4627b7f2956e5ba7ef29c3cc3ca488cf15854838a8f72"},
-    {file = "cryptography-39.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:887cbc1ea60786e534b00ba8b04d1095f4272d380ebd5f7a7eb4cc274710fad9"},
-    {file = "cryptography-39.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6f97109336df5c178ee7c9c711b264c502b905c2d2a29ace99ed761533a3460f"},
-    {file = "cryptography-39.0.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a6915075c6d3a5e1215eab5d99bcec0da26036ff2102a1038401d6ef5bef25b"},
-    {file = "cryptography-39.0.0-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:76c24dd4fd196a80f9f2f5405a778a8ca132f16b10af113474005635fe7e066c"},
-    {file = "cryptography-39.0.0-cp36-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:bae6c7f4a36a25291b619ad064a30a07110a805d08dc89984f4f441f6c1f3f96"},
-    {file = "cryptography-39.0.0-cp36-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:875aea1039d78557c7c6b4db2fe0e9d2413439f4676310a5f269dd342ca7a717"},
-    {file = "cryptography-39.0.0-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:f6c0db08d81ead9576c4d94bbb27aed8d7a430fa27890f39084c2d0e2ec6b0df"},
-    {file = "cryptography-39.0.0-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f3ed2d864a2fa1666e749fe52fb8e23d8e06b8012e8bd8147c73797c506e86f1"},
-    {file = "cryptography-39.0.0-cp36-abi3-win32.whl", hash = "sha256:f671c1bb0d6088e94d61d80c606d65baacc0d374e67bf895148883461cd848de"},
-    {file = "cryptography-39.0.0-cp36-abi3-win_amd64.whl", hash = "sha256:e324de6972b151f99dc078defe8fb1b0a82c6498e37bff335f5bc6b1e3ab5a1e"},
-    {file = "cryptography-39.0.0-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:754978da4d0457e7ca176f58c57b1f9de6556591c19b25b8bcce3c77d314f5eb"},
-    {file = "cryptography-39.0.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ee1fd0de9851ff32dbbb9362a4d833b579b4a6cc96883e8e6d2ff2a6bc7104f"},
-    {file = "cryptography-39.0.0-pp38-pypy38_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:fec8b932f51ae245121c4671b4bbc030880f363354b2f0e0bd1366017d891458"},
-    {file = "cryptography-39.0.0-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:407cec680e811b4fc829de966f88a7c62a596faa250fc1a4b520a0355b9bc190"},
-    {file = "cryptography-39.0.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:7dacfdeee048814563eaaec7c4743c8aea529fe3dd53127313a792f0dadc1773"},
-    {file = "cryptography-39.0.0-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:ad04f413436b0781f20c52a661660f1e23bcd89a0e9bb1d6d20822d048cf2856"},
-    {file = "cryptography-39.0.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50386acb40fbabbceeb2986332f0287f50f29ccf1497bae31cf5c3e7b4f4b34f"},
-    {file = "cryptography-39.0.0-pp39-pypy39_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:e5d71c5d5bd5b5c3eebcf7c5c2bb332d62ec68921a8c593bea8c394911a005ce"},
-    {file = "cryptography-39.0.0-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:844ad4d7c3850081dffba91cdd91950038ee4ac525c575509a42d3fc806b83c8"},
-    {file = "cryptography-39.0.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:e0a05aee6a82d944f9b4edd6a001178787d1546ec7c6223ee9a848a7ade92e39"},
-    {file = "cryptography-39.0.0.tar.gz", hash = "sha256:f964c7dcf7802d133e8dbd1565914fa0194f9d683d82411989889ecd701e8adf"},
+    {file = "cryptography-39.0.1-cp36-abi3-macosx_10_12_universal2.whl", hash = "sha256:6687ef6d0a6497e2b58e7c5b852b53f62142cfa7cd1555795758934da363a965"},
+    {file = "cryptography-39.0.1-cp36-abi3-macosx_10_12_x86_64.whl", hash = "sha256:706843b48f9a3f9b9911979761c91541e3d90db1ca905fd63fee540a217698bc"},
+    {file = "cryptography-39.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:5d2d8b87a490bfcd407ed9d49093793d0f75198a35e6eb1a923ce1ee86c62b41"},
+    {file = "cryptography-39.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83e17b26de248c33f3acffb922748151d71827d6021d98c70e6c1a25ddd78505"},
+    {file = "cryptography-39.0.1-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e124352fd3db36a9d4a21c1aa27fd5d051e621845cb87fb851c08f4f75ce8be6"},
+    {file = "cryptography-39.0.1-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:5aa67414fcdfa22cf052e640cb5ddc461924a045cacf325cd164e65312d99502"},
+    {file = "cryptography-39.0.1-cp36-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:35f7c7d015d474f4011e859e93e789c87d21f6f4880ebdc29896a60403328f1f"},
+    {file = "cryptography-39.0.1-cp36-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f24077a3b5298a5a06a8e0536e3ea9ec60e4c7ac486755e5fb6e6ea9b3500106"},
+    {file = "cryptography-39.0.1-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:f0c64d1bd842ca2633e74a1a28033d139368ad959872533b1bab8c80e8240a0c"},
+    {file = "cryptography-39.0.1-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:0f8da300b5c8af9f98111ffd512910bc792b4c77392a9523624680f7956a99d4"},
+    {file = "cryptography-39.0.1-cp36-abi3-win32.whl", hash = "sha256:fe913f20024eb2cb2f323e42a64bdf2911bb9738a15dba7d3cce48151034e3a8"},
+    {file = "cryptography-39.0.1-cp36-abi3-win_amd64.whl", hash = "sha256:ced4e447ae29ca194449a3f1ce132ded8fcab06971ef5f618605aacaa612beac"},
+    {file = "cryptography-39.0.1-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:807ce09d4434881ca3a7594733669bd834f5b2c6d5c7e36f8c00f691887042ad"},
+    {file = "cryptography-39.0.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:96f1157a7c08b5b189b16b47bc9db2332269d6680a196341bf30046330d15388"},
+    {file = "cryptography-39.0.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:e422abdec8b5fa8462aa016786680720d78bdce7a30c652b7fadf83a4ba35336"},
+    {file = "cryptography-39.0.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:b0afd054cd42f3d213bf82c629efb1ee5f22eba35bf0eec88ea9ea7304f511a2"},
+    {file = "cryptography-39.0.1-pp39-pypy39_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:6f8ba7f0328b79f08bdacc3e4e66fb4d7aab0c3584e0bd41328dce5262e26b2e"},
+    {file = "cryptography-39.0.1-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:ef8b72fa70b348724ff1218267e7f7375b8de4e8194d1636ee60510aae104cd0"},
+    {file = "cryptography-39.0.1-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:aec5a6c9864be7df2240c382740fcf3b96928c46604eaa7f3091f58b878c0bb6"},
+    {file = "cryptography-39.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:fdd188c8a6ef8769f148f88f859884507b954cc64db6b52f66ef199bb9ad660a"},
+    {file = "cryptography-39.0.1.tar.gz", hash = "sha256:d1f6198ee6d9148405e49887803907fe8962a23e6c6f83ea7d98f1c0de375695"},
 ]
 curies = [
     {file = "curies-0.4.2-py3-none-any.whl", hash = "sha256:91d6993a59270c3c280d3689e26001eb7c098d319f9a9f102c060943fa2bc44b"},
@@ -2938,8 +2950,8 @@ filelock = [
     {file = "filelock-3.9.0.tar.gz", hash = "sha256:7b319f24340b51f55a2bf7a12ac0755a9b03e718311dac567a0f4f7fabd2f5de"},
 ]
 flake8 = [
-    {file = "flake8-5.0.4-py2.py3-none-any.whl", hash = "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"},
-    {file = "flake8-5.0.4.tar.gz", hash = "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db"},
+    {file = "flake8-6.0.0-py2.py3-none-any.whl", hash = "sha256:3833794e27ff64ea4e9cf5d410082a8b97ff1a06c16aa3d2027339cd0f1195c7"},
+    {file = "flake8-6.0.0.tar.gz", hash = "sha256:c61007e76655af75e6785a931f452915b371dc48f56efd765247c8fe68f2b181"},
 ]
 fqdn = [
     {file = "fqdn-1.5.1-py3-none-any.whl", hash = "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014"},
@@ -3204,8 +3216,8 @@ lark = [
     {file = "lark-1.1.5.tar.gz", hash = "sha256:4b534eae1f9af5b4ea000bea95776350befe1981658eea3820a01c37e504bb4d"},
 ]
 linkml = [
-    {file = "linkml-1.4.3-py3-none-any.whl", hash = "sha256:778603d56f8d4f2e285c63eac0324ece68fe76f018f3a0638dcb3b03fa5c3262"},
-    {file = "linkml-1.4.3.tar.gz", hash = "sha256:0e071d9d6a62924f650172b9fac09fd5626f744363c4d3e67494cdd142251489"},
+    {file = "linkml-1.4.4-py3-none-any.whl", hash = "sha256:82c701fd242174108ca11c18afa4e81c0d231c78ee1c3bfd33c27dfe8663ad25"},
+    {file = "linkml-1.4.4.tar.gz", hash = "sha256:5699c2e2016bc89a48cf645f462f970585bf31b88442ef56305d2e2192c30649"},
 ]
 linkml-dataops = [
     {file = "linkml_dataops-0.1.0-py3-none-any.whl", hash = "sha256:193cf7f659e5f07946d2c2761896910d5f7151d91282543b1363801f68307f4c"},
@@ -3216,8 +3228,8 @@ linkml-renderer = [
     {file = "linkml_renderer-0.1.2.tar.gz", hash = "sha256:f368a7e4e70faa794c180efdf77f8670e85b4dd35bfd5bba8ecf1af4475fd88e"},
 ]
 linkml-runtime = [
-    {file = "linkml-runtime-1.4.3.tar.gz", hash = "sha256:748ab9d3c7b417471d3077140ae2a11302d0735c12525f94f19c465473e1b3c2"},
-    {file = "linkml_runtime-1.4.3-py3-none-any.whl", hash = "sha256:bf1ef87d4884955e786841ed2c71a4bbc8fa0fc4acc2fcaff6f590cf9e3b5ecb"},
+    {file = "linkml-runtime-1.4.5.tar.gz", hash = "sha256:bdb6260dfd9b050a6edce8e72061e77e7080471d5d53e694805cb948c8c9f473"},
+    {file = "linkml_runtime-1.4.5-py3-none-any.whl", hash = "sha256:fc1149c59e038a45e5d46c677a19b5dfc15dedce3ef967eed2ee3e0958fd2e49"},
 ]
 markdown-it-py = [
     {file = "markdown-it-py-2.1.0.tar.gz", hash = "sha256:cf7e59fed14b5ae17c0006eff14a2d9a00ed5f3a846148153899a0224e2c07da"},
@@ -3372,40 +3384,36 @@ multidict = [
     {file = "multidict-6.0.4.tar.gz", hash = "sha256:3666906492efb76453c0e7b97f2cf459b0682e7402c0489a95484965dbc1da49"},
 ]
 mypy = [
-    {file = "mypy-0.991-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7d17e0a9707d0772f4a7b878f04b4fd11f6f5bcb9b3813975a9b13c9332153ab"},
-    {file = "mypy-0.991-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0714258640194d75677e86c786e80ccf294972cc76885d3ebbb560f11db0003d"},
-    {file = "mypy-0.991-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0c8f3be99e8a8bd403caa8c03be619544bc2c77a7093685dcf308c6b109426c6"},
-    {file = "mypy-0.991-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc9ec663ed6c8f15f4ae9d3c04c989b744436c16d26580eaa760ae9dd5d662eb"},
-    {file = "mypy-0.991-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4307270436fd7694b41f913eb09210faff27ea4979ecbcd849e57d2da2f65305"},
-    {file = "mypy-0.991-cp310-cp310-win_amd64.whl", hash = "sha256:901c2c269c616e6cb0998b33d4adbb4a6af0ac4ce5cd078afd7bc95830e62c1c"},
-    {file = "mypy-0.991-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d13674f3fb73805ba0c45eb6c0c3053d218aa1f7abead6e446d474529aafc372"},
-    {file = "mypy-0.991-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1c8cd4fb70e8584ca1ed5805cbc7c017a3d1a29fb450621089ffed3e99d1857f"},
-    {file = "mypy-0.991-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:209ee89fbb0deed518605edddd234af80506aec932ad28d73c08f1400ef80a33"},
-    {file = "mypy-0.991-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37bd02ebf9d10e05b00d71302d2c2e6ca333e6c2a8584a98c00e038db8121f05"},
-    {file = "mypy-0.991-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:26efb2fcc6b67e4d5a55561f39176821d2adf88f2745ddc72751b7890f3194ad"},
-    {file = "mypy-0.991-cp311-cp311-win_amd64.whl", hash = "sha256:3a700330b567114b673cf8ee7388e949f843b356a73b5ab22dd7cff4742a5297"},
-    {file = "mypy-0.991-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:1f7d1a520373e2272b10796c3ff721ea1a0712288cafaa95931e66aa15798813"},
-    {file = "mypy-0.991-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:641411733b127c3e0dab94c45af15fea99e4468f99ac88b39efb1ad677da5711"},
-    {file = "mypy-0.991-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:3d80e36b7d7a9259b740be6d8d906221789b0d836201af4234093cae89ced0cd"},
-    {file = "mypy-0.991-cp37-cp37m-win_amd64.whl", hash = "sha256:e62ebaad93be3ad1a828a11e90f0e76f15449371ffeecca4a0a0b9adc99abcef"},
-    {file = "mypy-0.991-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:b86ce2c1866a748c0f6faca5232059f881cda6dda2a893b9a8373353cfe3715a"},
-    {file = "mypy-0.991-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ac6e503823143464538efda0e8e356d871557ef60ccd38f8824a4257acc18d93"},
-    {file = "mypy-0.991-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0cca5adf694af539aeaa6ac633a7afe9bbd760df9d31be55ab780b77ab5ae8bf"},
-    {file = "mypy-0.991-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a12c56bf73cdab116df96e4ff39610b92a348cc99a1307e1da3c3768bbb5b135"},
-    {file = "mypy-0.991-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:652b651d42f155033a1967739788c436491b577b6a44e4c39fb340d0ee7f0d70"},
-    {file = "mypy-0.991-cp38-cp38-win_amd64.whl", hash = "sha256:4175593dc25d9da12f7de8de873a33f9b2b8bdb4e827a7cae952e5b1a342e243"},
-    {file = "mypy-0.991-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:98e781cd35c0acf33eb0295e8b9c55cdbef64fcb35f6d3aa2186f289bed6e80d"},
-    {file = "mypy-0.991-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6d7464bac72a85cb3491c7e92b5b62f3dcccb8af26826257760a552a5e244aa5"},
-    {file = "mypy-0.991-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c9166b3f81a10cdf9b49f2d594b21b31adadb3d5e9db9b834866c3258b695be3"},
-    {file = "mypy-0.991-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8472f736a5bfb159a5e36740847808f6f5b659960115ff29c7cecec1741c648"},
-    {file = "mypy-0.991-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5e80e758243b97b618cdf22004beb09e8a2de1af481382e4d84bc52152d1c476"},
-    {file = "mypy-0.991-cp39-cp39-win_amd64.whl", hash = "sha256:74e259b5c19f70d35fcc1ad3d56499065c601dfe94ff67ae48b85596b9ec1461"},
-    {file = "mypy-0.991-py3-none-any.whl", hash = "sha256:de32edc9b0a7e67c2775e574cb061a537660e51210fbf6006b0b36ea695ae9bb"},
-    {file = "mypy-0.991.tar.gz", hash = "sha256:3c0165ba8f354a6d9881809ef29f1a9318a236a6d81c690094c5df32107bde06"},
+    {file = "mypy-1.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e0626db16705ab9f7fa6c249c017c887baf20738ce7f9129da162bb3075fc1af"},
+    {file = "mypy-1.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1ace23f6bb4aec4604b86c4843276e8fa548d667dbbd0cb83a3ae14b18b2db6c"},
+    {file = "mypy-1.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87edfaf344c9401942883fad030909116aa77b0fa7e6e8e1c5407e14549afe9a"},
+    {file = "mypy-1.0.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0ab090d9240d6b4e99e1fa998c2d0aa5b29fc0fb06bd30e7ad6183c95fa07593"},
+    {file = "mypy-1.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:7cc2c01dfc5a3cbddfa6c13f530ef3b95292f926329929001d45e124342cd6b7"},
+    {file = "mypy-1.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:14d776869a3e6c89c17eb943100f7868f677703c8a4e00b3803918f86aafbc52"},
+    {file = "mypy-1.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bb2782a036d9eb6b5a6efcdda0986774bf798beef86a62da86cb73e2a10b423d"},
+    {file = "mypy-1.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5cfca124f0ac6707747544c127880893ad72a656e136adc935c8600740b21ff5"},
+    {file = "mypy-1.0.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8845125d0b7c57838a10fd8925b0f5f709d0e08568ce587cc862aacce453e3dd"},
+    {file = "mypy-1.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b1b9e1ed40544ef486fa8ac022232ccc57109f379611633ede8e71630d07d2"},
+    {file = "mypy-1.0.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c7cf862aef988b5fbaa17764ad1d21b4831436701c7d2b653156a9497d92c83c"},
+    {file = "mypy-1.0.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5cd187d92b6939617f1168a4fe68f68add749902c010e66fe574c165c742ed88"},
+    {file = "mypy-1.0.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:4e5175026618c178dfba6188228b845b64131034ab3ba52acaffa8f6c361f805"},
+    {file = "mypy-1.0.0-cp37-cp37m-win_amd64.whl", hash = "sha256:2f6ac8c87e046dc18c7d1d7f6653a66787a4555085b056fe2d599f1f1a2a2d21"},
+    {file = "mypy-1.0.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7306edca1c6f1b5fa0bc9aa645e6ac8393014fa82d0fa180d0ebc990ebe15964"},
+    {file = "mypy-1.0.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:3cfad08f16a9c6611e6143485a93de0e1e13f48cfb90bcad7d5fde1c0cec3d36"},
+    {file = "mypy-1.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67cced7f15654710386e5c10b96608f1ee3d5c94ca1da5a2aad5889793a824c1"},
+    {file = "mypy-1.0.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:a86b794e8a56ada65c573183756eac8ac5b8d3d59daf9d5ebd72ecdbb7867a43"},
+    {file = "mypy-1.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:50979d5efff8d4135d9db293c6cb2c42260e70fb010cbc697b1311a4d7a39ddb"},
+    {file = "mypy-1.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3ae4c7a99e5153496243146a3baf33b9beff714464ca386b5f62daad601d87af"},
+    {file = "mypy-1.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5e398652d005a198a7f3c132426b33c6b85d98aa7dc852137a2a3be8890c4072"},
+    {file = "mypy-1.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be78077064d016bc1b639c2cbcc5be945b47b4261a4f4b7d8923f6c69c5c9457"},
+    {file = "mypy-1.0.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:92024447a339400ea00ac228369cd242e988dd775640755fa4ac0c126e49bb74"},
+    {file = "mypy-1.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:fe523fcbd52c05040c7bee370d66fee8373c5972171e4fbc323153433198592d"},
+    {file = "mypy-1.0.0-py3-none-any.whl", hash = "sha256:2efa963bdddb27cb4a0d42545cd137a8d2b883bd181bbc4525b568ef6eca258f"},
+    {file = "mypy-1.0.0.tar.gz", hash = "sha256:f34495079c8d9da05b183f9f7daec2878280c2ad7cc81da686ef0b484cea2ecf"},
 ]
 mypy-extensions = [
-    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
-    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
 ]
 myst-parser = [
     {file = "myst-parser-0.18.1.tar.gz", hash = "sha256:79317f4bb2c13053dd6e64f9da1ba1da6cd9c40c8a430c447a7b146a594c246d"},
@@ -3419,34 +3427,34 @@ networkx = [
     {file = "networkx-2.8.8.tar.gz", hash = "sha256:230d388117af870fce5647a3c52401fcf753e94720e6ea6b4197a5355648885e"},
 ]
 numpy = [
-    {file = "numpy-1.24.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:179a7ef0889ab769cc03573b6217f54c8bd8e16cef80aad369e1e8185f994cd7"},
-    {file = "numpy-1.24.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b09804ff570b907da323b3d762e74432fb07955701b17b08ff1b5ebaa8cfe6a9"},
-    {file = "numpy-1.24.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f1b739841821968798947d3afcefd386fa56da0caf97722a5de53e07c4ccedc7"},
-    {file = "numpy-1.24.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e3463e6ac25313462e04aea3fb8a0a30fb906d5d300f58b3bc2c23da6a15398"},
-    {file = "numpy-1.24.1-cp310-cp310-win32.whl", hash = "sha256:b31da69ed0c18be8b77bfce48d234e55d040793cebb25398e2a7d84199fbc7e2"},
-    {file = "numpy-1.24.1-cp310-cp310-win_amd64.whl", hash = "sha256:b07b40f5fb4fa034120a5796288f24c1fe0e0580bbfff99897ba6267af42def2"},
-    {file = "numpy-1.24.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7094891dcf79ccc6bc2a1f30428fa5edb1e6fb955411ffff3401fb4ea93780a8"},
-    {file = "numpy-1.24.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:28e418681372520c992805bb723e29d69d6b7aa411065f48216d8329d02ba032"},
-    {file = "numpy-1.24.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e274f0f6c7efd0d577744f52032fdd24344f11c5ae668fe8d01aac0422611df1"},
-    {file = "numpy-1.24.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0044f7d944ee882400890f9ae955220d29b33d809a038923d88e4e01d652acd9"},
-    {file = "numpy-1.24.1-cp311-cp311-win32.whl", hash = "sha256:442feb5e5bada8408e8fcd43f3360b78683ff12a4444670a7d9e9824c1817d36"},
-    {file = "numpy-1.24.1-cp311-cp311-win_amd64.whl", hash = "sha256:de92efa737875329b052982e37bd4371d52cabf469f83e7b8be9bb7752d67e51"},
-    {file = "numpy-1.24.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b162ac10ca38850510caf8ea33f89edcb7b0bb0dfa5592d59909419986b72407"},
-    {file = "numpy-1.24.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:26089487086f2648944f17adaa1a97ca6aee57f513ba5f1c0b7ebdabbe2b9954"},
-    {file = "numpy-1.24.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:caf65a396c0d1f9809596be2e444e3bd4190d86d5c1ce21f5fc4be60a3bc5b36"},
-    {file = "numpy-1.24.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b0677a52f5d896e84414761531947c7a330d1adc07c3a4372262f25d84af7bf7"},
-    {file = "numpy-1.24.1-cp38-cp38-win32.whl", hash = "sha256:dae46bed2cb79a58d6496ff6d8da1e3b95ba09afeca2e277628171ca99b99db1"},
-    {file = "numpy-1.24.1-cp38-cp38-win_amd64.whl", hash = "sha256:6ec0c021cd9fe732e5bab6401adea5a409214ca5592cd92a114f7067febcba0c"},
-    {file = "numpy-1.24.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:28bc9750ae1f75264ee0f10561709b1462d450a4808cd97c013046073ae64ab6"},
-    {file = "numpy-1.24.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:84e789a085aabef2f36c0515f45e459f02f570c4b4c4c108ac1179c34d475ed7"},
-    {file = "numpy-1.24.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e669fbdcdd1e945691079c2cae335f3e3a56554e06bbd45d7609a6cf568c700"},
-    {file = "numpy-1.24.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef85cf1f693c88c1fd229ccd1055570cb41cdf4875873b7728b6301f12cd05bf"},
-    {file = "numpy-1.24.1-cp39-cp39-win32.whl", hash = "sha256:87a118968fba001b248aac90e502c0b13606721b1343cdaddbc6e552e8dfb56f"},
-    {file = "numpy-1.24.1-cp39-cp39-win_amd64.whl", hash = "sha256:ddc7ab52b322eb1e40521eb422c4e0a20716c271a306860979d450decbb51b8e"},
-    {file = "numpy-1.24.1-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:ed5fb71d79e771ec930566fae9c02626b939e37271ec285e9efaf1b5d4370e7d"},
-    {file = "numpy-1.24.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad2925567f43643f51255220424c23d204024ed428afc5aad0f86f3ffc080086"},
-    {file = "numpy-1.24.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:cfa1161c6ac8f92dea03d625c2d0c05e084668f4a06568b77a25a89111621566"},
-    {file = "numpy-1.24.1.tar.gz", hash = "sha256:2386da9a471cc00a1f47845e27d916d5ec5346ae9696e01a8a34760858fe9dd2"},
+    {file = "numpy-1.24.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:eef70b4fc1e872ebddc38cddacc87c19a3709c0e3e5d20bf3954c147b1dd941d"},
+    {file = "numpy-1.24.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e8d2859428712785e8a8b7d2b3ef0a1d1565892367b32f915c4a4df44d0e64f5"},
+    {file = "numpy-1.24.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6524630f71631be2dabe0c541e7675db82651eb998496bbe16bc4f77f0772253"},
+    {file = "numpy-1.24.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a51725a815a6188c662fb66fb32077709a9ca38053f0274640293a14fdd22978"},
+    {file = "numpy-1.24.2-cp310-cp310-win32.whl", hash = "sha256:2620e8592136e073bd12ee4536149380695fbe9ebeae845b81237f986479ffc9"},
+    {file = "numpy-1.24.2-cp310-cp310-win_amd64.whl", hash = "sha256:97cf27e51fa078078c649a51d7ade3c92d9e709ba2bfb97493007103c741f1d0"},
+    {file = "numpy-1.24.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7de8fdde0003f4294655aa5d5f0a89c26b9f22c0a58790c38fae1ed392d44a5a"},
+    {file = "numpy-1.24.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4173bde9fa2a005c2c6e2ea8ac1618e2ed2c1c6ec8a7657237854d42094123a0"},
+    {file = "numpy-1.24.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4cecaed30dc14123020f77b03601559fff3e6cd0c048f8b5289f4eeabb0eb281"},
+    {file = "numpy-1.24.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a23f8440561a633204a67fb44617ce2a299beecf3295f0d13c495518908e910"},
+    {file = "numpy-1.24.2-cp311-cp311-win32.whl", hash = "sha256:e428c4fbfa085f947b536706a2fc349245d7baa8334f0c5723c56a10595f9b95"},
+    {file = "numpy-1.24.2-cp311-cp311-win_amd64.whl", hash = "sha256:557d42778a6869c2162deb40ad82612645e21d79e11c1dc62c6e82a2220ffb04"},
+    {file = "numpy-1.24.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d0a2db9d20117bf523dde15858398e7c0858aadca7c0f088ac0d6edd360e9ad2"},
+    {file = "numpy-1.24.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:c72a6b2f4af1adfe193f7beb91ddf708ff867a3f977ef2ec53c0ffb8283ab9f5"},
+    {file = "numpy-1.24.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c29e6bd0ec49a44d7690ecb623a8eac5ab8a923bce0bea6293953992edf3a76a"},
+    {file = "numpy-1.24.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2eabd64ddb96a1239791da78fa5f4e1693ae2dadc82a76bc76a14cbb2b966e96"},
+    {file = "numpy-1.24.2-cp38-cp38-win32.whl", hash = "sha256:e3ab5d32784e843fc0dd3ab6dcafc67ef806e6b6828dc6af2f689be0eb4d781d"},
+    {file = "numpy-1.24.2-cp38-cp38-win_amd64.whl", hash = "sha256:76807b4063f0002c8532cfeac47a3068a69561e9c8715efdad3c642eb27c0756"},
+    {file = "numpy-1.24.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4199e7cfc307a778f72d293372736223e39ec9ac096ff0a2e64853b866a8e18a"},
+    {file = "numpy-1.24.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:adbdce121896fd3a17a77ab0b0b5eedf05a9834a18699db6829a64e1dfccca7f"},
+    {file = "numpy-1.24.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:889b2cc88b837d86eda1b17008ebeb679d82875022200c6e8e4ce6cf549b7acb"},
+    {file = "numpy-1.24.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f64bb98ac59b3ea3bf74b02f13836eb2e24e48e0ab0145bbda646295769bd780"},
+    {file = "numpy-1.24.2-cp39-cp39-win32.whl", hash = "sha256:63e45511ee4d9d976637d11e6c9864eae50e12dc9598f531c035265991910468"},
+    {file = "numpy-1.24.2-cp39-cp39-win_amd64.whl", hash = "sha256:a77d3e1163a7770164404607b7ba3967fb49b24782a6ef85d9b5f54126cc39e5"},
+    {file = "numpy-1.24.2-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:92011118955724465fb6853def593cf397b4a1367495e0b59a7e69d40c4eb71d"},
+    {file = "numpy-1.24.2-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9006288bcf4895917d02583cf3411f98631275bc67cce355a7f39f8c14338fa"},
+    {file = "numpy-1.24.2-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:150947adbdfeceec4e5926d956a06865c1c690f2fd902efede4ca6fe2e657c3f"},
+    {file = "numpy-1.24.2.tar.gz", hash = "sha256:003a9f530e880cb2cd177cba1af7220b9aa42def9c4afc2a2fc3ee6be7eb2b22"},
 ]
 numpydoc = [
     {file = "numpydoc-1.5.0-py3-none-any.whl", hash = "sha256:c997759fb6fc32662801cece76491eedbc0ec619b514932ffd2b270ae89c07f9"},
@@ -3528,8 +3536,8 @@ pkginfo = [
     {file = "pkginfo-1.9.6.tar.gz", hash = "sha256:8fd5896e8718a4372f0ea9cc9d96f6417c9b986e23a4d116dda26b62cc29d046"},
 ]
 platformdirs = [
-    {file = "platformdirs-2.6.2-py3-none-any.whl", hash = "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490"},
-    {file = "platformdirs-2.6.2.tar.gz", hash = "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"},
+    {file = "platformdirs-3.0.0-py3-none-any.whl", hash = "sha256:b1d5eb14f221506f50d6604a561f4c5786d9e80355219694a1b244bcd96f4567"},
+    {file = "platformdirs-3.0.0.tar.gz", hash = "sha256:8a1228abb1ef82d788f74139988b137e78692984ec7b08eaa6c65f1723af28f9"},
 ]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
@@ -3564,8 +3572,8 @@ py = [
     {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
 pycodestyle = [
-    {file = "pycodestyle-2.9.1-py2.py3-none-any.whl", hash = "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"},
-    {file = "pycodestyle-2.9.1.tar.gz", hash = "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785"},
+    {file = "pycodestyle-2.10.0-py2.py3-none-any.whl", hash = "sha256:8a4eaf0d0495c7395bdab3589ac2db602797d76207242c17d470186815706610"},
+    {file = "pycodestyle-2.10.0.tar.gz", hash = "sha256:347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053"},
 ]
 pycparser = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
@@ -3610,8 +3618,8 @@ pydantic = [
     {file = "pydantic-1.10.4.tar.gz", hash = "sha256:b9a3859f24eb4e097502a3be1fb4b2abb79b6103dd9e2e0edb70613a4459a648"},
 ]
 pyflakes = [
-    {file = "pyflakes-2.5.0-py2.py3-none-any.whl", hash = "sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2"},
-    {file = "pyflakes-2.5.0.tar.gz", hash = "sha256:491feb020dca48ccc562a8c0cbe8df07ee13078df59813b83959cbdada312ea3"},
+    {file = "pyflakes-3.0.1-py2.py3-none-any.whl", hash = "sha256:ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf"},
+    {file = "pyflakes-3.0.1.tar.gz", hash = "sha256:ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd"},
 ]
 pygments = [
     {file = "Pygments-2.14.0-py3-none-any.whl", hash = "sha256:fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717"},
@@ -3953,8 +3961,8 @@ semsql = [
     {file = "semsql-0.2.5.tar.gz", hash = "sha256:049544bcac42c05fd21d9be9ba3b9696935a7ae2f54769ebd32abd0ea36e1d1d"},
 ]
 setuptools = [
-    {file = "setuptools-67.0.0-py3-none-any.whl", hash = "sha256:9d790961ba6219e9ff7d9557622d2fe136816a264dd01d5997cfc057d804853d"},
-    {file = "setuptools-67.0.0.tar.gz", hash = "sha256:883131c5b6efa70b9101c7ef30b2b7b780a4283d5fc1616383cdf22c83cbefe6"},
+    {file = "setuptools-67.2.0-py3-none-any.whl", hash = "sha256:16ccf598aab3b506593c17378473978908a2734d7336755a8769b480906bec1c"},
+    {file = "setuptools-67.2.0.tar.gz", hash = "sha256:b440ee5f7e607bb8c9de15259dba2583dd41a38879a7abc1d43a71c59524da48"},
 ]
 shexjsg = [
     {file = "ShExJSG-0.8.2-py2.py3-none-any.whl", hash = "sha256:3b0d8432dd313bee9e1343382c5e02e9908dd941a7dd7342bf8c0200fe523766"},
@@ -3993,8 +4001,8 @@ sphinx-click = [
     {file = "sphinx_click-4.4.0-py3-none-any.whl", hash = "sha256:2821c10a68fc9ee6ce7c92fad26540d8d8c8f45e6d7258f0e4fb7529ae8fab49"},
 ]
 sphinx-rtd-theme = [
-    {file = "sphinx_rtd_theme-1.1.1-py2.py3-none-any.whl", hash = "sha256:31faa07d3e97c8955637fc3f1423a5ab2c44b74b8cc558a51498c202ce5cbda7"},
-    {file = "sphinx_rtd_theme-1.1.1.tar.gz", hash = "sha256:6146c845f1e1947b3c3dd4432c28998a1693ccc742b4f9ad7c63129f0757c103"},
+    {file = "sphinx_rtd_theme-1.2.0-py2.py3-none-any.whl", hash = "sha256:f823f7e71890abe0ac6aaa6013361ea2696fc8d3e1fa798f463e82bdb77eeff2"},
+    {file = "sphinx_rtd_theme-1.2.0.tar.gz", hash = "sha256:a0d8bd1a2ed52e0b338cbe19c4b2eef3c5e7a048769753dac6a9f059c7b641b8"},
 ]
 sphinxcontrib-applehelp = [
     {file = "sphinxcontrib-applehelp-1.0.4.tar.gz", hash = "sha256:828f867945bbe39817c210a1abfd1bc4895c8b73fcaade56d45357a348a07d7e"},
@@ -4007,6 +4015,10 @@ sphinxcontrib-devhelp = [
 sphinxcontrib-htmlhelp = [
     {file = "sphinxcontrib-htmlhelp-2.0.1.tar.gz", hash = "sha256:0cbdd302815330058422b98a113195c9249825d681e18f11e8b1f78a2f11efff"},
     {file = "sphinxcontrib_htmlhelp-2.0.1-py3-none-any.whl", hash = "sha256:c38cb46dccf316c79de6e5515e1770414b797162b23cd3d06e67020e1d2a6903"},
+]
+sphinxcontrib-jquery = [
+    {file = "sphinxcontrib-jquery-2.0.0.tar.gz", hash = "sha256:8fb65f6dba84bf7bcd1aea1f02ab3955ac34611d838bcc95d4983b805b234daa"},
+    {file = "sphinxcontrib_jquery-2.0.0-py3-none-any.whl", hash = "sha256:ed47fa425c338ffebe3c37e1cdb56e30eb806116b85f01055b158c7057fdb995"},
 ]
 sphinxcontrib-jsmath = [
     {file = "sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"},
@@ -4137,8 +4149,8 @@ validators = [
     {file = "validators-0.20.0.tar.gz", hash = "sha256:24148ce4e64100a2d5e267233e23e7afeb55316b47d30faae7eb6e7292bc226a"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.17.1-py3-none-any.whl", hash = "sha256:ce3b1684d6e1a20a3e5ed36795a97dfc6af29bc3970ca8dab93e11ac6094b3c4"},
-    {file = "virtualenv-20.17.1.tar.gz", hash = "sha256:f8b927684efc6f1cc206c9db297a570ab9ad0e51c16fa9e45487d36d1905c058"},
+    {file = "virtualenv-20.19.0-py3-none-any.whl", hash = "sha256:54eb59e7352b573aa04d53f80fc9736ed0ad5143af445a1e539aada6eb947dd1"},
+    {file = "virtualenv-20.19.0.tar.gz", hash = "sha256:37a640ba82ed40b226599c522d411e4be5edb339a0c0de030c0dc7b646d61590"},
 ]
 watchdog = [
     {file = "watchdog-2.2.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a09483249d25cbdb4c268e020cb861c51baab2d1affd9a6affc68ffe6a231260"},
@@ -4179,8 +4191,8 @@ webencodings = [
     {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
 ]
 websocket-client = [
-    {file = "websocket-client-1.5.0.tar.gz", hash = "sha256:561ca949e5bbb5d33409a37235db55c279235c78ee407802f1d2314fff8a8536"},
-    {file = "websocket_client-1.5.0-py3-none-any.whl", hash = "sha256:fb5d81b95d350f3a54838ebcb4c68a5353bbd1412ae8f068b1e5280faeb13074"},
+    {file = "websocket-client-1.5.1.tar.gz", hash = "sha256:3f09e6d8230892547132177f575a4e3e73cfdf06526e20cc02aa1c3b47184d40"},
+    {file = "websocket_client-1.5.1-py3-none-any.whl", hash = "sha256:cdf5877568b7e83aa7cf2244ab56a3213de587bbe0ce9d8b9600fc77b455d89e"},
 ]
 wrapt = [
     {file = "wrapt-1.14.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3"},
@@ -4325,6 +4337,6 @@ yarl = [
     {file = "yarl-1.8.2.tar.gz", hash = "sha256:49d43402c6e3013ad0978602bf6bf5328535c48d192304b91b97a3c6790b1562"},
 ]
 zipp = [
-    {file = "zipp-3.12.0-py3-none-any.whl", hash = "sha256:9eb0a4c5feab9b08871db0d672745b53450d7f26992fd1e4653aa43345e97b86"},
-    {file = "zipp-3.12.0.tar.gz", hash = "sha256:73efd63936398aac78fd92b6f4865190119d6c91b531532e798977ea8dd402eb"},
+    {file = "zipp-3.12.1-py3-none-any.whl", hash = "sha256:6c4fe274b8f85ec73c37a8e4e3fa00df9fb9335da96fb789e3b96b318e5097b3"},
+    {file = "zipp-3.12.1.tar.gz", hash = "sha256:a3cac813d40993596b39ea9e93a18e8a2076d5c378b8bc88ec32ab264e04ad02"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -179,7 +179,7 @@ css = ["tinycss2 (>=1.1.0,<1.2)"]
 
 [[package]]
 name = "bmt"
-version = "1.0.0"
+version = "1.0.2"
 description = "Biolink Model Toolkit: A Python API for working with the Biolink Model"
 category = "main"
 optional = false
@@ -2558,7 +2558,7 @@ multidict = ">=4.0"
 
 [[package]]
 name = "zipp"
-version = "3.12.1"
+version = "3.13.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
@@ -2574,7 +2574,7 @@ docs = ["numpydoc", "sphinx", "myst-parser"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "592e13dcc9f5595f423411f6cddcddda7e02b99e004a2aaaac533017efd80cc6"
+content-hash = "5ed48e691daeac24ba488a0d49a8296c517168888d0186a3a9ba440faa43eb19"
 
 [metadata.files]
 aiohttp = [
@@ -2653,8 +2653,8 @@ bleach = [
     {file = "bleach-6.0.0.tar.gz", hash = "sha256:1a1a85c1595e07d8db14c5f09f09e6433502c51c595970edc090551f0db99414"},
 ]
 bmt = [
-    {file = "bmt-1.0.0-py3-none-any.whl", hash = "sha256:4fd04dc5f90108cdded0d18e79a503db997dd80925ceb699d61651616fb62899"},
-    {file = "bmt-1.0.0.tar.gz", hash = "sha256:b48f31001b961bd9ef70042b4087ff0c61e931a22074b12b40c16d47fb2a2833"},
+    {file = "bmt-1.0.2-py3-none-any.whl", hash = "sha256:eac827ad05bbc4b930d2910b92443d3938e961cd851ba3016d73305030127386"},
+    {file = "bmt-1.0.2.tar.gz", hash = "sha256:aa9dfa5c049982406a22b299e555eb3d5a9398eec67ef8a892fd85edd5837889"},
 ]
 cachetools = [
     {file = "cachetools-5.3.0-py3-none-any.whl", hash = "sha256:429e1a1e845c008ea6c85aa35d4b98b65d6a9763eeef3e37e92728a12d1de9d4"},
@@ -4337,6 +4337,6 @@ yarl = [
     {file = "yarl-1.8.2.tar.gz", hash = "sha256:49d43402c6e3013ad0978602bf6bf5328535c48d192304b91b97a3c6790b1562"},
 ]
 zipp = [
-    {file = "zipp-3.12.1-py3-none-any.whl", hash = "sha256:6c4fe274b8f85ec73c37a8e4e3fa00df9fb9335da96fb789e3b96b318e5097b3"},
-    {file = "zipp-3.12.1.tar.gz", hash = "sha256:a3cac813d40993596b39ea9e93a18e8a2076d5c378b8bc88ec32ab264e04ad02"},
+    {file = "zipp-3.13.0-py3-none-any.whl", hash = "sha256:e8b2a36ea17df80ffe9e2c4fda3f693c3dad6df1697d3cd3af232db680950b0b"},
+    {file = "zipp-3.13.0.tar.gz", hash = "sha256:23f70e964bc11a34cef175bc90ba2914e1e4545ea1e3e2f67c079671883f9cb6"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-bmt = "^1.0.0"
+bmt = "^1.0.2"
 kgx = "^1.7.0"
 pytest = "7.2.0"
 jsonschema = "^4.17.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,13 +40,12 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
+bmt = "^1.0.0"
 kgx = "^1.7.0"
+pytest = "7.2.0"
 jsonschema = "^4.17.0"
 PyYAML = "^6.0"
 requests = "^2.28.1"
-linkml-runtime = "^1.4"
-linkml = "^1.4.3"
-bmt = "^1.0.0"
 fastapi = "^0.68"
 pydantic = "^1.8.0"
 uvicorn = "^0.15"
@@ -56,7 +55,6 @@ myst-parser = { version = "^0.18.1", extras = ["docs"] }
 numpy = "^1.23.5"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "7.2.0"
 
 [tool.poetry.urls]
 "Change Log" = "https://github.com/NCATSTranslator/reasoner-validator/blob/master/CHANGELOG.md"

--- a/reasoner_validator/codes.yaml
+++ b/reasoner_validator/codes.yaml
@@ -21,14 +21,13 @@ info:
         mixin:
           $message: "'{name}' is a mixin."
           $description: "Input Edge data can have 'mixin' category classes."
-    edge:
-      predicate:
-        abstract:
-            $message: "'{name}' is abstract."
-            $description: "Input Edge data can have 'abstract' predicates."
-        mixin:
-          $message: "'{name}' is a mixin."
-          $description: "Input Edge data can have 'mixin' predicates."
+    predicate:
+      abstract:
+          $message: "'{name}' is abstract."
+          $description: "Input Edge data can have 'abstract' predicates."
+      mixin:
+        $message: "'{name}' is a mixin."
+        $description: "Input Edge data can have 'mixin' predicates."
   query_graph:
     node:
       category:
@@ -81,14 +80,13 @@ warning:
         unmapped_to_category:
           $message: "'{node_id}' has identifiers {unmapped_ids} unmapped to the target categories: {categories}?"
           $description: "The namespaces of Biolink model node of specified category may be incomplete with respect to identifiers being used in input edge data?"
-    edge:
-      predicate:
-        deprecated:
-          $message: "'{name}' is deprecated?"
-          $description: "Input data edge predicate is deprecated in the current model, to be removed in the future. Review Biolink Model for a suitable replacement?"
-        non_canonical:
-          $message: "{context} edge {edge_id} predicate '{predicate}' is non-canonical?"
-          $description: "A predicate selected for use as input data should preferably be tagged as 'canonical' in the specified Biolink Model release?"
+    predicate:
+      deprecated:
+        $message: "'{name}' is deprecated?"
+        $description: "Input data edge predicate is deprecated in the current model, to be removed in the future. Review Biolink Model for a suitable replacement?"
+      non_canonical:
+        $message: "{context} edge {edge_id} predicate '{predicate}' is non-canonical?"
+        $description: "A predicate selected for use as input data should preferably be tagged as 'canonical' in the specified Biolink Model release?"
   query_graph:
     node:
       ids:
@@ -199,9 +197,12 @@ error:
   input_edge:
     node:
       category:
+        missing:
+          $message: "Input edge node '{node_id}' is missing its category!"
+          $description: "Category value must be specified in an input test data edge!"
         unknown:
-          $message: "'{name}' is unknown!"
-          $description: "Category specified in input test data edge node is not recorded in specified version of Biolink. Replace with a concrete category!"
+          $message: "Input edge node '{node_id}' has unknown category '{category}'!"
+          $description: "Category specified in input test data edge node is not recorded in specified version of Biolink. Replace with a known category!"
         abstract:
           $message: "'{name}' is abstract!"
           $description: "Category specified in input test data edge node is 'abstract' in specified version of Biolink. Replace with a concrete category!"
@@ -212,17 +213,22 @@ error:
         missing:
           $message: "{context} node identifier is missing!"
           $description: "Input test data edge data needs to have a specific node identifier for testing!"
-    edge:
-      predicate:
-        missing:
-          $message: "{context} edge '{edge_id}' predicate is missing or empty!"
-          $description: "Input test edge data needs to have a specific edge predicate for testing!"
-        abstract:
-            $message: "'{name}' is abstract!"
-            $description: "Input Edge data validation is currently strict: cannot have 'abstract' predicates!"
-        mixin:
-          $message: "'{name}' is a mixin1"
-          $description: "Input Edge data validation is currently strict: cannot have 'mixin' predicates!"
+    predicate:
+      missing:
+        $message: "{context} edge '{edge_id}' predicate is missing or empty!"
+        $description: "Input test edge data needs to have a specific edge predicate for testing!"
+      unknown:
+        $message: "'{name}' is unknown predicate!"
+        $description: "Predicate specified in input test data edge is not recorded in specified version of Biolink. Replace with a known predicate!"
+      abstract:
+        $message: "'{name}' is abstract predicate!"
+        $description: "Input Edge data validation is currently strict: predicates cannot be 'abstract'. Replace with a concrete predicate!"
+      mixin:
+        $message: "'{name}' is a mixin predicate!"
+        $description: "Input Edge data validation is currently strict: predicates cannot be of type 'mixin'. Replace with a concrete predicate!"
+      invalid:
+        $message: "Edge '{edge_id}' predicate '{predicate}' is invalid!"
+        $description: "Predicate specified in Input Edge is not defined as a predicate in specified version of Biolink. Replace with a proper predicate!"
   query_graph:
     node:
       category:
@@ -248,10 +254,27 @@ error:
           $message: "Node '{node_id}.is_set' slot is not a boolean value!"
           $description: "The 'is_set' field in node of Query Graph, if present, must be a boolean value!"
     edge:
+      subject:
+        missing:
+          $message: "Edge '{edge_id}' has a missing or empty 'subject' slot value!"
+          $description: "Query graph edge must have a 'subject' key with a non-empty associated value!"
+        missing_from_nodes:
+          $message: "Edge 'subject' id '{object_id}' is missing from the nodes catalog!"
+          $description: "Every 'subject' identifier of every edge in a Query Graph must also be recorded in the list of nodes for that graph!"
+      object:
+        missing:
+          $message: "Edge '{edge_id}' has a missing or empty 'object' slot value!"
+          $description: "Query graph edge must have a 'object' key with a non-empty associated value!"
+        missing_from_nodes:
+          $message: "Edge 'object' id '{object_id}' is missing from the nodes catalog!"
+          $description: "Every 'object' identifier of every edge in a Query Graph must also be recorded in the list of nodes for that graph!"
       predicate:
         missing:
           $message: "Edge '{edge_id}' predicate is missing or empty!"
           $description: "The predicate of Query Graph edge needs to specified using a 'predicate' key with an array list of one or more predicates!"
+        unknown:
+          $message: "Edge '{edge_id}' predicate '{predicate}' is unknown!"
+          $description: "Predicate specified in Query Graph edge is not defined in specified version of Biolink. Replace with a defined predicate!"
         not_array:
           $message: "Edge '{edge_id}' predicate slot value is not an array!"
           $description: "Value of 'predicate' slot value in Query Graph must be an array data type!"
@@ -264,31 +287,22 @@ error:
         mixin:
           $message: "'{name}' is a mixin!"
           $description: "Query Graph data validation is currently strict: cannot have 'mixin' predicates!"
+        invalid:
+          $message: "Edge '{edge_id}' predicate '{predicate}' is invalid!"
+          $description: "Predicate specified in Query Graph edge is not defined as a predicate in specified version of Biolink. Replace with a proper predicate!"
       attribute_constraints:
         not_array:
           $message: "Edge '{edge_id}' attribute_constraints property value is not an array!"
           $description: "Value of 'attribute_constraints' slot value in a Query Graph must be an array data type!"
       qualifier_constraints:
         qualifier_set:
-          value:
+          empty:
+              $message: "Edge '{edge_id}' qualifier_set property value is empty!"
+              $description: "Value of a 'qualifier_constraints.qualifier_set' property in a Query Graph must not be non-empty array!"
+          qualifier:
             invalid:
-              $message: "Edge '{edge_id}' qualifier_set property value is empty or not a JSON object!"
-              $description: "Value of a 'qualifier_set' property in a Query Graph must be non-empty array!"
-            qualifier:
-              qualifier_type_id:
-                not_biolink_curie:
-                  $message: "Edge '{edge_id}' qualifier_type_id {identifier} is not a Biolink CURIE!"
-                  $description: "A qualifier qualifier_type_id property value in a Query Graph must be a Biolink CURIE!"
-                unknown:
-                  $message: "Edge '{edge_id}' qualifier_type_id {identifier} is unknown!"
-                  $description: "This 'qualifier_type_id' in the Query Graph is undefined in the Biolink Model!"
-                invalid:
-                  $message: "Edge '{edge_id}' qualifier_type_id {identifier} is not a valid Biolink qualifier type id!"
-                  $description: "This 'qualifier_type_id' in the Query Graph not properly defined in the Biolink Model!"
-                range:
-                  missing:
-                    $message: "The value range of edge '{edge_id}' qualifier_type_id {identifier} is undefined!"
-                    $description: "The 'qualifier_type_id' in the Query Graph needs to have a defined enum or category value range!"
+              $message: "Edge '{edge_id}' qualifier entry is invalid!"
+              $description: "A 'qualifier' entry must be a valid JSON object with valid 'qualifier_type_id' and corresponding 'qualifier_value'!"
   knowledge_graph:
     nodes:
       empty:

--- a/reasoner_validator/codes.yaml
+++ b/reasoner_validator/codes.yaml
@@ -41,15 +41,25 @@ info:
       predicate:
         abstract:
           $message: "'{name}' is abstract."
-          $description: "TRAPI Message Query Graphs can have 'mixin' predicates."
+          $description: "TRAPI Messages in Query Graphs can have 'mixin' predicates."
         mixin:
           $message: "'{name}' is a mixin."
-          $description: "TRAPI Message Query Graphs can have 'mixin' predicates."
+          $description: "TRAPI Messages in Query Graphs can have 'mixin' predicates."
   attribute_type_id:
     non_biolink_prefix:
       $message: "Edge attribute_type_id '{attribute_type_id}' has a non-Biolink CURIE prefix mapped to Biolink."
       $description: "Non-Biolink CURIEs are tolerated as term value for the attribute_type_id properties of edge attributes."
-
+  knowledge_graph:
+    node:
+      category:
+        abstract:
+          $message: "'{name}' is abstract."
+          $description: "TRAPI Messages in Knowledge Graphs can have 'abstract' category classes when the mode of validation is 'non-strict'.."
+    edge:
+      predicate:
+        abstract:
+          $message: "'{name}' is abstract."
+          $description: "TRAPI Messages in Knowledge Graphs can have 'abstract' predicates when the mode of validation is 'non-strict'."
 warning:
   trapi:
     response:

--- a/reasoner_validator/codes.yaml
+++ b/reasoner_validator/codes.yaml
@@ -424,3 +424,10 @@ error:
         not_array:
           $message: "Edge '{edge_id}' 'qualifiers' are not an array!"
           $description: "Value of the 'qualifiers' slot in Knowledge Graph edge must be an array of attributes!"
+        empty:
+          $message: "Edge '{edge_id}' qualifiers property value is empty!"
+          $description: "Value of a 'qualifiers' property in a Knowledge Graph must not be non-empty array!"
+        qualifier:
+          invalid:
+            $message: "Edge '{edge_id}' qualifier entry is invalid!"
+            $description: "A 'qualifier' entry must be a valid JSON object with valid 'qualifier_type_id' and corresponding 'qualifier_value'!"

--- a/reasoner_validator/report.py
+++ b/reasoner_validator/report.py
@@ -198,11 +198,13 @@ class ValidationReporter:
         :param message: named parameters representing extra (str-formatted) context for the given code message
         :return: None (internally record the validation message)
         """
+        # Sanity check: that the given code has been registered in the codes.yaml file
+        assert CodeDictionary.get_code_entry(code) is not None, f"ValidationReporter.report: unknown code '{code}'"
+
         message_type = self.get_message_type(code)
         message_set = self._message_type_name[message_type]
         if code not in self.messages[message_set]:
             self.messages[message_set][code] = list()
-
         # TODO: how can **message content duplication be avoided here(?)
         if message:
             self.messages[message_set][code].append(message)

--- a/reasoner_validator/validation_codes.py
+++ b/reasoner_validator/validation_codes.py
@@ -138,7 +138,7 @@ class CodeDictionary:
         :param code: Optional[str], dot delimited validation message code identifier (None is ok, but returns None)
         :param facet: Optional[str], constraint on code entry facet to be returned; if specified, should be either
                                      "message" or "description" (default: return all facets of the code entry)
-        :return: Dict, single terminal leaf code entry (complete with indicated or all facets)
+        :return: Dict, single terminal leaf code entry (complete with indicated or all facets); None, if not available
         """
         value: Optional[Tuple[str, Dict[str, str]]] = cls.get_code_subtree(code, facet=facet, is_leaf=True)
         if not value:

--- a/tests/test_biolink_compliance_validation.py
+++ b/tests/test_biolink_compliance_validation.py
@@ -180,7 +180,7 @@ KNOWLEDGE_GRAPH_PREFIX = f"{BLM_VERSION_PREFIX} Knowledge Graph"
             },
             # f"{INPUT_EDGE_PREFIX}: WARNING - Predicate element " +
             # "'binds' is deprecated?"  # in Biolink 3.1.1
-            "warning.input_edge.edge.predicate.deprecated"
+            "warning.input_edge.predicate.deprecated"
         ),
         (   # Query 8 - Predicate is abstract
             LATEST_BIOLINK_MODEL_VERSION,
@@ -192,7 +192,7 @@ KNOWLEDGE_GRAPH_PREFIX = f"{BLM_VERSION_PREFIX} Knowledge Graph"
                 'object': 'ORCID:56789'
             },
             # f"{INPUT_EDGE_PREFIX}: INFO - Predicate element 'biolink:contributor' is abstract."
-            "info.input_edge.edge.predicate.abstract"
+            "info.input_edge.predicate.abstract"
         ),
         (   # Query 9 - Predicate is a mixin
             LATEST_BIOLINK_MODEL_VERSION,
@@ -204,7 +204,7 @@ KNOWLEDGE_GRAPH_PREFIX = f"{BLM_VERSION_PREFIX} Knowledge Graph"
                 'object': 'GO:0006094'  # Gluconeogenesis
             },
             # f"{INPUT_EDGE_PREFIX}: INFO - Predicate element 'biolink:decreases_amount_or_activity_of' is a mixin."
-            "info.input_edge.edge.predicate.mixin"
+            "info.input_edge.predicate.mixin"
         ),
         (   # Query 10 - Unknown predicate element
             LATEST_BIOLINK_MODEL_VERSION,
@@ -216,7 +216,7 @@ KNOWLEDGE_GRAPH_PREFIX = f"{BLM_VERSION_PREFIX} Knowledge Graph"
                 'object': 'UBERON:0035769'
             },
             # f"{INPUT_EDGE_PREFIX}: ERROR - Predicate element 'biolink:not_a_predicate' is unknown!"
-            "error.input_edge.edge.predicate.unknown"
+            "error.input_edge.predicate.unknown"
         ),
         (   # Query 11 - Invalid or unknown predicate
             LATEST_BIOLINK_MODEL_VERSION,
@@ -227,8 +227,8 @@ KNOWLEDGE_GRAPH_PREFIX = f"{BLM_VERSION_PREFIX} Knowledge Graph"
                 'subject': 'UBERON:0005453',
                 'object': 'UBERON:0035769'
             },
-            # f"{INPUT_EDGE_PREFIX}: ERROR - Predicate element 'biolink:has_unit' is inavlid!"
-            "error.input_edge.edge.predicate.invalid"
+            # f"{INPUT_EDGE_PREFIX}: ERROR - Predicate element 'biolink:has_unit' is invalid!"
+            "error.input_edge.predicate.invalid"
         ),
         (   # Query 12 - Non-canonical directed predicate
             LATEST_BIOLINK_MODEL_VERSION,
@@ -240,7 +240,7 @@ KNOWLEDGE_GRAPH_PREFIX = f"{BLM_VERSION_PREFIX} Knowledge Graph"
                 'object': 'MONDO:0005148'
             },
             # f"{INPUT_EDGE_PREFIX}: WARNING - Edge predicate 'biolink:affected_by' is non-canonical?"
-            "warning.input_edge.edge.predicate.non_canonical"
+            "warning.input_edge.predicate.non_canonical"
         ),
         (   # Query 13 - Missing subject
             LATEST_BIOLINK_MODEL_VERSION,  # Biolink Model Version
@@ -1117,12 +1117,26 @@ def test_validate_attributes(query: Tuple):
         (  # Query 8 - 'qualifier_set' object value is not an array - invalidated by TRAPI schema
             {
                 'qualifier_constraints': [
-                    {"qualifier_set": {}}
+                    {
+                        "qualifier_set": {}
+                    }
                 ]
             },
             "error.trapi.validation"
         ),
-        (  # Query 9 - 'qualifier' entry is not a JSON object (dictionary) - invalidated by TRAPI schema
+        (  # Query 9 - 'qualifier' entry in the qualifier_set is empty - invalidated by TRAPI schema
+            {
+                'qualifier_constraints': [
+                    {
+                        "qualifier_set": [
+                            None
+                        ]
+                    }
+                ]
+            },
+            "error.trapi.validation"
+        ),
+        (  # Query 10 - 'qualifier' entry is not a JSON object (dictionary) - invalidated by TRAPI schema
             {
                 'qualifier_constraints': [
                     {
@@ -1134,7 +1148,7 @@ def test_validate_attributes(query: Tuple):
             },
             "error.trapi.validation"
         ),
-        (  # Query 10 - 'qualifier' entry is missing its 'qualifier_type_id' property - invalidated by TRAPI schema
+        (  # Query 11 - 'qualifier' entry is missing its 'qualifier_type_id' property - invalidated by TRAPI schema
             {
                 'qualifier_constraints': [
                     {
@@ -1149,7 +1163,7 @@ def test_validate_attributes(query: Tuple):
             },
             "error.trapi.validation"
         ),
-        (  # Query 11 - 'qualifier_type_id' property value is not a Biolink CURIE
+        (  # Query 12 - 'qualifier_type_id' property value is not a Biolink CURIE
             {
                 'qualifier_constraints': [
                     {
@@ -1164,7 +1178,7 @@ def test_validate_attributes(query: Tuple):
             },
             "error.query_graph.edge.qualifier_constraints.qualifier_set.qualifier.invalid"
         ),
-        (  # Query 12 - 'qualifier_type_id' property value is unknown
+        (  # Query 13 - 'qualifier_type_id' property value is unknown
             {
                 'qualifier_constraints': [
                     {
@@ -1179,7 +1193,7 @@ def test_validate_attributes(query: Tuple):
             },
             "error.query_graph.edge.qualifier_constraints.qualifier_set.qualifier.invalid"
         ),
-        (  # Query 13 - 'qualifier_type_id' property value is valid but abstract
+        (  # Query 14 - 'qualifier_type_id' property value is valid but abstract
             {
                 'qualifier_constraints': [
                     {
@@ -1192,9 +1206,10 @@ def test_validate_attributes(query: Tuple):
                     }
                 ]
             },
-            "info.query_graph.edge.qualifier.abstract"
+            # "info.query_graph.edge.qualifier.abstract"
+            "error.query_graph.edge.qualifier_constraints.qualifier_set.qualifier.invalid"
         ),
-        (  # Query 14 - 'qualifier_type_id' property value is not a Biolink qualifier term
+        (  # Query 15 - 'qualifier_type_id' property value is not a Biolink qualifier term
             {
                 'qualifier_constraints': [
                     {
@@ -1209,7 +1224,7 @@ def test_validate_attributes(query: Tuple):
             },
             "error.query_graph.edge.qualifier_constraints.qualifier_set.qualifier.invalid"
         ),
-        (  # Query 15 - 'qualifier' entry is missing its 'qualifier_value' property - invalidated by TRAPI schema
+        (  # Query 16 - 'qualifier' entry is missing its 'qualifier_value' property - invalidated by TRAPI schema
             {
                 'qualifier_constraints': [
                     {
@@ -1223,7 +1238,7 @@ def test_validate_attributes(query: Tuple):
             },
             "error.trapi.validation"
         ),
-        (   # Query 16 - qualifier_type_id 'object_direction_qualifier' is a valid Biolink qualifier type and
+        (   # Query 17 - qualifier_type_id 'object_direction_qualifier' is a valid Biolink qualifier type and
             #            'upregulated' a valid corresponding 'permissible value' enum 'qualifier_value'
             {
                 'qualifier_constraints': [
@@ -1239,22 +1254,23 @@ def test_validate_attributes(query: Tuple):
             },
             ""    # this particular use case should pass
         ),
-        (   # Query 17 - 'qualifier_type_id' is a valid Biolink qualifier type and 'RO:0002213'
-            #            is an 'exact match' to a 'upregulated', the above 'qualifier_value'
-            {
-                'qualifier_constraints': [
-                    {
-                        "qualifier_set": [
-                            {
-                                'qualifier_type_id': "biolink:object_direction_qualifier",
-                                'qualifier_value': "RO:0002213"   # RO 'exact match' term for 'upregulated'
-                            }
-                        ]
-                    }
-                ]
-            },
-            ""    # this other use case should also pass
-        ),
+        # (   #  *** Currently unsupported use case:
+        #     # Query xx - 'qualifier_type_id' is a valid Biolink qualifier type and 'RO:0002213'
+        #     #            is an 'exact match' to a 'upregulated', the above 'qualifier_value'
+        #     {
+        #         'qualifier_constraints': [
+        #             {
+        #                 "qualifier_set": [
+        #                     {
+        #                         'qualifier_type_id': "biolink:object_direction_qualifier",
+        #                         'qualifier_value': "RO:0002213"   # RO 'exact match' term for 'upregulated'
+        #                     }
+        #                 ]
+        #             }
+        #         ]
+        #     },
+        #     ""    # this other use case should also pass
+        # ),
         (   # Query 18 - 'qualifier_type_id' is a valid Biolink qualifier type and
             #             'UBERON:0001981' a valid corresponding 'reachable from' enum 'qualifier_value'
             {
@@ -1273,7 +1289,7 @@ def test_validate_attributes(query: Tuple):
         )
     ]
 )
-def test_validate_qualifier_constraints(query: Tuple):
+def test_validate_qualifier_constraints(query: Tuple[Dict, str]):
     # Sanity check: does TRAPI validation catch this first?
     trapi_validator = TRAPISchemaValidator(trapi_version=LATEST_TRAPI_VERSION)
     # Wrap Qualifiers inside a small mock QEdge
@@ -2051,16 +2067,6 @@ def test_validate_qualifier_constraints(query: Tuple):
                         "categories": [
                             "biolink:SmallMolecule"  # Not valid in the latest model?
                         ],
-                        "attributes": [
-                            {
-                                "attribute_source": "infores:chembl",
-                                "attribute_type_id": "biolink:highest_FDA_approval_status",
-                                "attributes": [],
-                                "original_attribute_name": "max_phase",
-                                "value": "FDA Clinical Research Phase 2",
-                                "value_type_id": "biolink:FDA_approval_status_enum"
-                            }
-                        ]
                     }
                 },
                 # Sample edge
@@ -2069,30 +2075,9 @@ def test_validate_qualifier_constraints(query: Tuple):
                        "subject": "NCBIGene:29974",
                        "predicate": "biolink:physically_interacts_with",
                        "object": "PUBCHEM.COMPOUND:597",
-                       "attributes": [
-                           {
-                               "attribute_source": "infores:hmdb",
-                               "attribute_type_id": "biolink:primary_knowledge_source",
-                               "attributes": [],
-                               "description": "MolePro's HMDB target transformer",
-                               "original_attribute_name": "biolink:primary_knowledge_source",
-                               "value": "infores:hmdb",
-                               "value_type_id": "biolink:InformationResource"
-                           },
-                           {
-                               "attribute_source": "infores:hmdb",
-                               "attribute_type_id": "biolink:aggregator_knowledge_source",
-                               "attributes": [],
-                               "description": "Molecular Data Provider",
-                               "original_attribute_name": "biolink:aggregator_knowledge_source",
-                               "value": "infores:molepro",
-                               "value_type_id": "biolink:InformationResource"
-                           }
-                        ]
                     }
                 }
             },
-            # f"{KNOWLEDGE_GRAPH_PREFIX}: ERROR - Knowledge Graph Node element 'biolink:SmallMolecule' is unknown!"
             "error.knowledge_graph.node.category.unknown"
         )
     ]

--- a/tests/test_biolink_compliance_validation.py
+++ b/tests/test_biolink_compliance_validation.py
@@ -26,10 +26,12 @@ logger.setLevel("DEBUG")
 
 pp = PrettyPrinter(indent=4)
 
+# TRAPI 1.4 is still a work-in-progress as of February 2023, so we stay with 1.3 for now(?)
+LATEST_TRAPI_VERSION = "1.3"
+
 # January 25, 2023 - as of reasoner-validator 3.1.0, we don't pretend to totally support Biolink Models
 # any earlier than 3.1.1.  If earlier biolink model compliance testing is desired,
 # then perhaps reasoner-validator version 3.0.5 or earlier can be used.
-LATEST_TRAPI_VERSION = "1.4"
 LATEST_BIOLINK_MODEL_VERSION = "3.2.0"
 
 
@@ -1328,11 +1330,11 @@ def test_validate_qualifier_constraints(query: Tuple[Dict, str]):
             {},
             ""
         ),
-        (  # Query 1 - 'qualifiers' value is None - invalidated by TRAPI schema
+        (  # Query 1 - 'qualifiers' value is nullable: true, this should pass
             {
                 'qualifiers': None
             },
-            "error.trapi.validation"
+            ""
         ),
         (  # Query 2 - 'qualifiers' value is not an array - invalidated by TRAPI schema
             {
@@ -1378,7 +1380,7 @@ def test_validate_qualifier_constraints(query: Tuple[Dict, str]):
                     }
                 ]
             },
-            "error.query_graph.edge.qualifier_constraints.qualifier_set.qualifier.invalid"
+            "error.knowledge_graph.edge.qualifiers.qualifier.invalid"
         ),
         (  # Query 8 - 'qualifier_type_id' property value is unknown
             {
@@ -1389,7 +1391,7 @@ def test_validate_qualifier_constraints(query: Tuple[Dict, str]):
                     }
                 ]
             },
-            "error.query_graph.edge.qualifier_constraints.qualifier_set.qualifier.invalid"
+            "error.knowledge_graph.edge.qualifiers.qualifier.invalid"
         ),
         (  # Query 9 - 'qualifier_type_id' property value is valid but abstract
             {
@@ -1401,7 +1403,7 @@ def test_validate_qualifier_constraints(query: Tuple[Dict, str]):
                 ]
             },
             # "info.query_graph.edge.qualifier.abstract"
-            "error.query_graph.edge.qualifier_constraints.qualifier_set.qualifier.invalid"
+            "error.knowledge_graph.edge.qualifiers.qualifier.invalid"
         ),
         (  # Query 10 - 'qualifier_type_id' property value is not a Biolink qualifier term
             {
@@ -1412,7 +1414,7 @@ def test_validate_qualifier_constraints(query: Tuple[Dict, str]):
                     }
                 ]
             },
-            "error.query_graph.edge.qualifier_constraints.qualifier_set.qualifier.invalid"
+            "error.knowledge_graph.edge.qualifiers.qualifier.invalid"
         ),
         (  # Query 11 - 'qualifier' entry is missing its 'qualifier_value' property - invalidated by TRAPI schema
             {

--- a/tests/test_biolink_compliance_validation.py
+++ b/tests/test_biolink_compliance_validation.py
@@ -30,7 +30,7 @@ pp = PrettyPrinter(indent=4)
 # any earlier than 3.1.1.  If earlier biolink model compliance testing is desired,
 # then perhaps reasoner-validator version 3.0.5 or earlier can be used.
 LATEST_TRAPI_VERSION = "1.4"
-LATEST_BIOLINK_MODEL_VERSION = "3.1.1"
+LATEST_BIOLINK_MODEL_VERSION = "3.2.0"
 
 
 def test_set_default_biolink_versioned_global_environment():
@@ -1162,7 +1162,7 @@ def test_validate_attributes(query: Tuple):
                     }
                 ]
             },
-            "error.query_graph.edge.qualifier_constraints.qualifier_set.qualifier.qualifier_type_id.not_biolink_curie"
+            "error.query_graph.edge.qualifier_constraints.qualifier_set.qualifier.invalid"
         ),
         (  # Query 12 - 'qualifier_type_id' property value is unknown
             {
@@ -1177,16 +1177,16 @@ def test_validate_attributes(query: Tuple):
                     }
                 ]
             },
-            "error.query_graph.edge.qualifier.unknown"
+            "error.query_graph.edge.qualifier_constraints.qualifier_set.qualifier.invalid"
         ),
-        (  # Query 13 - 'qualifier_type_id' property value is abstract
+        (  # Query 13 - 'qualifier_type_id' property value is valid but abstract
             {
                 'qualifier_constraints': [
                     {
                         "qualifier_set": [
                             {
                                 'qualifier_type_id': "biolink:aspect_qualifier",
-                                'qualifier_value': "fake-qualifier-value"
+                                'qualifier_value': "stability"
                             }
                         ]
                     }
@@ -1207,7 +1207,7 @@ def test_validate_attributes(query: Tuple):
                     }
                 ]
             },
-            "error.query_graph.edge.qualifier_constraints.qualifier_set.qualifier.qualifier_type_id.invalid"
+            "error.query_graph.edge.qualifier_constraints.qualifier_set.qualifier.invalid"
         ),
         (  # Query 15 - 'qualifier' entry is missing its 'qualifier_value' property - invalidated by TRAPI schema
             {
@@ -1223,57 +1223,54 @@ def test_validate_attributes(query: Tuple):
             },
             "error.trapi.validation"
         ),
-        #
-        # TODO: reactivate these test data once Biolink Model Toolkit support for qualifiers is available
-        #
-        # (   # Query 16 - qualifier_type_id 'object_direction_qualifier' is a valid Biolink qualifier type and
-        #     #            'upregulated' a valid corresponding 'permissible value' enum 'qualifier_value'
-        #     {
-        #         'qualifier_constraints': [
-        #             {
-        #                 "qualifier_set": [
-        #                     {
-        #                         'qualifier_type_id': "biolink:object_direction_qualifier",
-        #                         'qualifier_value': "upregulated"
-        #                     }
-        #                 ]
-        #             }
-        #         ]
-        #     },
-        #     ""    # this particular use case should pass
-        # ),
-        # (   # Query 17 - 'qualifier_type_id' is a valid Biolink qualifier type and 'RO:0002213'
-        #     #            is an 'exact match' to a 'upregulated', the above 'qualifier_value'
-        #     {
-        #         'qualifier_constraints': [
-        #             {
-        #                 "qualifier_set": [
-        #                     {
-        #                         'qualifier_type_id': "biolink:object_direction_qualifier",
-        #                         'qualifier_value': "RO:0002213"   # RO 'exact match' term for 'upregulated'
-        #                     }
-        #                 ]
-        #             }
-        #         ]
-        #     },
-        #     ""    # this other use case should also pass
-        # ),
-        # (   # Query 18 - 'qualifier_type_id' is a valid Biolink qualifier type and
-        #     #             'UBERON:0001981' a valid corresponding 'reachable from' enum 'qualifier_value'
-        #     {
-        #         'qualifier_constraints': [
-        #             {
-        #                 "qualifier_set": [
-        #                     {
-        #                         'qualifier_type_id': "biolink:anatomical_context_qualifier",
-        #                         'qualifier_value': "UBERON:0001981"  # Blood Vessel
-        #                     }
-        #                 ]
-        #             }
-        #         ]
-        #     },
-        #     ""    # this particular use case should also pass
-        # )
+        (   # Query 16 - qualifier_type_id 'object_direction_qualifier' is a valid Biolink qualifier type and
+            #            'upregulated' a valid corresponding 'permissible value' enum 'qualifier_value'
+            {
+                'qualifier_constraints': [
+                    {
+                        "qualifier_set": [
+                            {
+                                'qualifier_type_id': "biolink:object_direction_qualifier",
+                                'qualifier_value': "upregulated"
+                            }
+                        ]
+                    }
+                ]
+            },
+            ""    # this particular use case should pass
+        ),
+        (   # Query 17 - 'qualifier_type_id' is a valid Biolink qualifier type and 'RO:0002213'
+            #            is an 'exact match' to a 'upregulated', the above 'qualifier_value'
+            {
+                'qualifier_constraints': [
+                    {
+                        "qualifier_set": [
+                            {
+                                'qualifier_type_id': "biolink:object_direction_qualifier",
+                                'qualifier_value': "RO:0002213"   # RO 'exact match' term for 'upregulated'
+                            }
+                        ]
+                    }
+                ]
+            },
+            ""    # this other use case should also pass
+        ),
+        (   # Query 18 - 'qualifier_type_id' is a valid Biolink qualifier type and
+            #             'UBERON:0001981' a valid corresponding 'reachable from' enum 'qualifier_value'
+            {
+                'qualifier_constraints': [
+                    {
+                        "qualifier_set": [
+                            {
+                                'qualifier_type_id': "biolink:anatomical_context_qualifier",
+                                'qualifier_value': "UBERON:0001981"  # Blood Vessel
+                            }
+                        ]
+                    }
+                ]
+            },
+            ""    # this particular use case should also pass
+        )
     ]
 )
 def test_validate_qualifier_constraints(query: Tuple):

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -10,7 +10,7 @@ TEST_BIOLINK_VERSION = "2.4.8"
 
 
 def check_messages(validator: ValidationReporter, code, no_errors: bool = False):
-    messages: Dict[str, Dict[str, List[Dict[str,str]]]] = validator.get_messages()
+    messages: Dict[str, Dict[str, List[Dict[str, str]]]] = validator.get_messages()
     if code:
         # TODO: 'code' should be found in code.yaml
         # value: Optional[Tuple[str, str]] = CodeDictionary.get_code_subtree(code)
@@ -170,6 +170,7 @@ def test_validator_reporter_message_display():
     assert "Test Validation Report: INFO - Input Edge Node Category: 'biolink:AdministrativeEntity' is abstract." \
         in messages
 
+
 def test_unknown_message_code():
     with pytest.raises(AssertionError):
         CodeDictionary.display(code="foo.bar")
@@ -179,17 +180,17 @@ def test_message_report():
     reporter = ValidationReporter(prefix="First Validation Report", trapi_version=TEST_TRAPI_VERSION)
     reporter.report(code="info.compliant")
     reporter.report(
-        code="info.input_edge.edge.predicate.abstract",
+        code="info.input_edge.predicate.abstract",
         name="biolink:contributor"
     )
-    report: Dict[str, Dict[str, List[Dict[str,str]]]] = reporter.get_messages()
+    report: Dict[str, Dict[str, List[Dict[str, str]]]] = reporter.get_messages()
     assert 'information' in report
     assert len(report['information']) > 0
     messages: List[str] = list()
     for code, parameters in report['information'].items():
-         messages.extend(CodeDictionary.display(code, parameters))
+        messages.extend(CodeDictionary.display(code, parameters))
     assert "INFO - Biolink Model-compliant TRAPI Message." in messages
-    assert "INFO - Input Edge Edge Predicate: 'biolink:contributor' is abstract." in messages
+    assert "INFO - Input Edge Predicate: 'biolink:contributor' is abstract." in messages
 
 
 def test_messages():
@@ -234,9 +235,9 @@ def test_messages():
     assert reporter1.get_biolink_version() == TEST_BIOLINK_VERSION
 
     # testing addition a few raw batch messages
-    new_messages: Dict[str, Dict[str, List[Dict[str,str]]]] = {
+    new_messages: Dict[str, Dict[str, List[Dict[str, str]]]] = {
         "information": {
-            "info.input_edge.edge.predicate.abstract": [
+            "info.input_edge.predicate.abstract": [
                 {
                     'context': "Well,... hello",
                     'name': "Dolly"
@@ -263,20 +264,20 @@ def test_messages():
     reporter1.add_messages(new_messages)
 
     # Verify what we have
-    messages: Dict[str, Dict[str, List[Dict[str,str]]]] = reporter1.get_messages()
+    messages: Dict[str, Dict[str, List[Dict[str, str]]]] = reporter1.get_messages()
 
     assert "information" in messages
     assert len(messages['information']) > 0
     information: List[str] = list()
     for code, parameters in messages['information'].items():
-         information.extend(CodeDictionary.display(code, parameters))
-    assert "INFO - Input Edge Edge Predicate: 'Dolly' is abstract." in information
+        information.extend(CodeDictionary.display(code, parameters))
+    assert "INFO - Input Edge Predicate: 'Dolly' is abstract." in information
 
     assert "warnings" in messages
     assert len(messages['warnings']) > 0
     warnings: List[str] = list()
     for code, parameters in messages['warnings'].items():
-         warnings.extend(CodeDictionary.display(code, parameters))
+        warnings.extend(CodeDictionary.display(code, parameters))
     assert "WARNING - Knowledge Graph Node Unmapped: 'Will Robinson' is unmapped " + \
            "to the target categories: Lost in Space?" in warnings
 
@@ -284,7 +285,7 @@ def test_messages():
     assert len(messages['errors']) > 0
     errors: List[str] = list()
     for code, parameters in messages['errors'].items():
-         errors.extend(CodeDictionary.display(code, parameters))
+        errors.extend(CodeDictionary.display(code, parameters))
     assert "ERROR - Trapi: TRAPI 6.6.6 schema exception: 'Dave, this can only be due to human error...'!" in errors
     
     obj = reporter1.to_dict()
@@ -293,7 +294,7 @@ def test_messages():
     assert "messages" in obj
     assert "errors" in obj["messages"]
     assert "error.trapi.validation" in obj["messages"]["errors"]
-    messages: List[Dict[str,str]] = obj["messages"]["errors"]["error.trapi.validation"]
+    messages: List[Dict[str, str]] = obj["messages"]["errors"]["error.trapi.validation"]
     assert "Dave, this can only be due to human error..."\
            in [message['exception'] for message in messages if 'exception' in message]
 
@@ -325,20 +326,20 @@ def test_validator_method():
 
     reporter.apply_validation(validator_method, test_data, **test_parameters)
 
-    messages: Dict[str, Dict[str, List[Dict[str,str]]]] = reporter.get_messages()
+    messages: Dict[str, Dict[str, List[Dict[str, str]]]] = reporter.get_messages()
 
     assert "warnings" in messages
     assert len(messages['warnings']) > 0
     warnings: List[str] = list()
     for code, parameters in messages['warnings'].items():
-         warnings.extend(CodeDictionary.display(code, parameters))
+        warnings.extend(CodeDictionary.display(code, parameters))
     assert "WARNING - Graph: Fake data is empty?" in warnings
 
     assert "errors" in messages
     assert len(messages['errors']) > 0
     errors: List[str] = list()
     for code, parameters in messages['errors'].items():
-         errors.extend(CodeDictionary.display(code, parameters))
+        errors.extend(CodeDictionary.display(code, parameters))
     assert "ERROR - Knowledge Graph Edge Provenance Infores: " + \
            "Edge has provenance value 'foo:bar' which is not a well-formed InfoRes CURIE!" in errors
 


### PR DESCRIPTION
Proposed v3.3.2

- Upgrade Python dependency to ^3.9 (BMT driven requirement)
- Upgrade Biolink Model Toolkit (BMT) to 1.0.2 to gain access to latest Biolink 3 qualifier validation methods
- Relatively full implementation of the Query Graph qualifier_constraints and Knowledge Graph qualifiers validation
- Added some new and repaired some existing validation codes and unit tests - all unit tests pass (TRAPI 1.3 and Biolink 3.2.0)